### PR TITLE
Relationships + QOLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the **Multihog D&D Framework** will be documented in this file.
 
+## [3.8.9] - 2026-07-01
+
+### Fixed
+- **NPC Portrait Generation Routing**: Fixed a bug where auto-generating portraits for NPCs incorrectly used the default Portrait AI connection settings instead of the dedicated Lorebook Agent AI connection settings, ensuring context-aware models handle the complex lorebook generation.
+- **NPC Word Count Cap**: Raised the internal hard cap for NPC major/minor section word targets from 100 to 1,000 words. Previously, typing a value like `400` in settings would silently clamp and save as `100`, forcing the AI to abbreviate lore. The quick-settings popup and main extension panel now correctly persist custom large limits.
+
 ## [3.8.8] - 2026-06-30
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the **Multihog D&D Framework** will be documented in this file.
 
-## [3.16.14] - 2026-06-25
+## [3.8.8] - 2026-06-30
 
 ### Added
 - **Relationship Bars System Rework**: Overhauled the NPC relationship bar system from a cosmetic feature into a functional, AI-driven mechanic. The narrator AI now emits inline annotations (e.g. `*(Affection: Elena +2 — sincere compliment)*`) at the point of interaction and machine tags (`[REL: Name | field | delta]`) at the end of each response. Tags are automatically parsed, deltas applied to the relationship bars (clamped ±100), and the updated values written back to lorebook NPC entries as the persistent campaign database. Context injection (`[NPC_RELATIONS]`) provides the narrator with a live snapshot of current standings for active NPCs only, keeping token usage minimal. System prompt guidance added with calibrated delta examples for both Friendship and Affection.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,15 @@
 
 All notable changes to the **Multihog D&D Framework** will be documented in this file.
 
+## [3.16.10] - 2026-06-25
+
+### Added
+- **Restored NPC Relationship Bars**: Reverted the removal of the NPC Relationship Bars feature, bringing it back in FULL.
+
 ## [3.16.9] - 2026-06-25
 
 ### Fixed
 - **Character Card Converter Toggle**: Added missing tree render refresh triggers on toggle checkbox state change, ensuring that toggling the setting immediately hides or shows the "Add NPC from Character Card" action button.
-
-## [3.16.8] - 2026-06-25
-
-### Removed
-- **NPC Relationship Bars and Editor**: Removed all relationship tracking infrastructure (UI bars, popup sliders, history log, prompts, schemas, tag parsers, and settings variables) to prevent dating-sim elements from interfering with campaign mechanics.
 
 ## [3.16.7] - 2026-06-25
 

--- a/constants.js
+++ b/constants.js
@@ -127,14 +127,6 @@ Current Time: HH:MM AM/PM, Day N
   xp: "Character Level and Experience Points (XP). Format as `Level: X | XP: current/max`. You MUST output this field whenever the narrative mentions gaining experience or leveling up.",
   quests: `Quest status updates ONLY. When a quest objective is completed, a quest concludes, or a new objective is added, emit a [QUESTS] block containing ONLY a JSON object with an "updates" array. Each entry must have the quest "id" and only the fields that changed or are new: "status" (active/completed/failed), "difficulty", and/or "objectives" (array). For updating an existing objective: include {"id", "status", "progress"}. For quantity-based objectives (e.g. "collect 6 mushrooms"), include "progress" as the current count (e.g. 4) even if the objective is not yet completed. To add a new objective: omit the "id" field and provide {"text", "required" (boolean), "status" (optional, defaults to "active"), "total" (optional), "progress" (optional)}. NOTE: Do NOT fail quests for time-out/deadline reasons (the system handles those automatically), but YOU MUST mark a quest as "failed" if it becomes narratively impossible (e.g. a protection target dies). Do NOT re-emit the full quest schema. If no quest changed, omit this block entirely.`,
   quests_legacy: `Track quests using the [QUESTS] block. Maintain the COMPLETE list of all quests at all times — active, completed, and failed. Only add a quest if [QUEST ACCEPTED] is outputted in the narrative. NEVER ADD A QUEST UNLESS YOU SEE [QUEST ACCEPTED]. A quest simply being listed does not mean it is accepted.
-  time_24h: `Current time and day grabbed from the status footer. Also track time of the last rest (only on Long Rest, e.g. 'Last Rest: 22:00, Day 0'). Use this to track out-of-combat buff durations by comparing to the PRIOR MEMO's time.
-
-Format (24-hour clock, NO AM/PM):
-Last Rest: HH:MM, Day N
-Current Time: HH:MM, Day N
-
-'Last Rest' is ONLY triggered on Long Rest, NOT Short Rest (when Hit Dice, etc, are spent.) If the [TIME] delta between PREVIOUS STATE MEMO and your current update is only an hour, it is a Short Rest.`,
-
 
 Format each quest exactly as shown:
 
@@ -154,7 +146,7 @@ QUEST: The Missing Sheep
   OBJ_TOTAL: 6
   OBJ_COMPLETED: Ask about the wolf
   OBJ_FAILED: Save the lamb
-- Use OBJ_ACTIVE / OBJ_COMPLETED / OBJ_FAILED markers. 
+- Use OBJ_ACTIVE / OBJ_COMPLETED / OBJ_FAILED markers.
 - Append ' (optional)' only if the task is not required.
 - For collection/count objectives, append [current/total] after the text (e.g. [4/6]) and add an OBJ_TOTAL line with the total. Update the count each turn as progress is made.
 - For rewards, use the REWARD marker (e.g. REWARD: 50 Gold). List multiple rewards on separate lines.
@@ -162,7 +154,15 @@ QUEST: The Missing Sheep
 - The MOOD field is calculated by the engine based on time pressure and the frustration coefficient. Use this to guide how the NPC speaks and acts.
 - Never delete old quests. Keep completed/failed ones with updated STATUS.
 - If no quests exist yet, emit [QUESTS][/QUESTS] (empty).`,
+  time_24h: `Current time and day grabbed from the status footer. Also track time of the last rest (only on Long Rest, e.g. 'Last Rest: 22:00, Day 0'). Use this to track out-of-combat buff durations by comparing to the PRIOR MEMO's time.
+
+Format (24-hour clock, NO AM/PM):
+Last Rest: HH:MM, Day N
+Current Time: HH:MM, Day N
+
+'Last Rest' is ONLY triggered on Long Rest, NOT Short Rest (when Hit Dice, etc, are spent.) If the [TIME] delta between PREVIOUS STATE MEMO and your current update is only an hour, it is a Short Rest.`,
 };
+
 
 export const QUESTS_NARRATOR_MODERN = `When the player formally accepts a quest from an NPC, you MUST call the LogQuest tool. Assign an appropriate difficulty (Very Easy to Very Hard) based on the narrative stakes. State how many objectives there are (there should always be multiple — they should be obtainable immediate objectives and not long term goals). If a duration is given (e.g., 'four days'), you MUST calculate the specific "Day N" timestamp based on the current in-world time. After LogQuest finishes, output *[QUEST ACCEPTED]*. Do NOT do this for rumors, casual mentions, or tasks the player has not yet agreed to. Use the MOOD field in the [QUESTS] block to guide how NPCs react to the player's progress or lack thereof.
 

--- a/constants.js
+++ b/constants.js
@@ -747,6 +747,27 @@ RELATIONSHIP TRACKING — only active when [NPC_RELATIONS] appears in context.
 WHEN TO EMIT:
 Be selective and natural about it. Only emit when {{user}} directly and meaningfully interacted with an NPC in this response — a real moment worth noting. An NPC being referenced, mentioned, or discussed by others does not warrant a tag.
 
+Relationship shifts are NOT limited to obvious social acts. Consider ALL of the following (non-exhaustive — use your judgment for ANY situation):
+• Direct compliments, insults, gifts, threats, apologies
+• Sharing a meal, campfire conversation, bonding over shared interests or memories
+• Surviving danger together, escaping a trap, enduring hardship side by side
+• Completing a quest that matters to the NPC, fulfilling a promise made to them
+• Betrayal, breaking a promise, abandoning or failing to protect them
+• Saving their life or a loved one's life
+• Flirtatious banter — received well OR poorly depending on the NPC's current feelings
+• A meaningful personal confession, a vulnerable moment shared
+• A romantic gesture — a dance, a gift with personal significance, a protective act in romantic context
+• Spending extended quality time together with positive interactions
+• Disrespecting their values, culture, religion, or loved ones
+• Ignoring them, forgetting something important to them, treating them as unimportant
+
+MAGNITUDE MUST reflect the NPC's personality. A stoic warrior might shift +1 where a warm innkeeper shifts +3 for the same compliment. Personality matters more than the act itself — gauge against WHO the NPC is, their temperament, values, and what they care about.
+
+DO NOT EMIT when:
+• The interaction is purely transactional with no emotional weight (buying supplies, asking for directions)
+• The NPC is not present or participating in the scene
+• Nothing meaningful happened between {{user}} and the specific NPC this turn
+
 INLINE ANNOTATION (visible — place immediately after the triggering moment):
 *(Friendship: Marcus +10 — saved his life in the alley)*
 *(Affection: Elena +2 — she seemed touched by the compliment)*
@@ -756,28 +777,32 @@ MACHINE TAGS (stripped before display — place ALL at the very end of the respo
   FirstName = NPC's first name only | field = friendship or affection | delta = signed integer
 
 FRIENDSHIP EXAMPLES (guides, not hard rules):
-+1/+2 ... Small warmth, casual kindness, shared laugh
-+2/+5 ... Genuine compliment, meaningful help with a problem
-+5/+10 .. Surviving danger together, real heartfelt conversation
-+10/+15 . Protecting or defending them, significant act of loyalty
-+15/+25 . Saving their life
++1/+2 ... Small warmth, casual kindness, shared laugh, pleasant campfire talk
++2/+5 ... Genuine compliment, meaningful help with a problem, bonding over shared interests
++5/+10 .. Surviving danger together, real heartfelt conversation, completing a shared goal
++10/+15 . Protecting or defending them, significant act of loyalty, keeping a difficult promise
++15/+25 . Saving their life, major self-sacrifice for their sake
 +25/+30 . Blood oath, brotherhood/sisterhood pact
--3/-5 ... Minor let-down, small broken promise
--5/-10 .. Insult, dismissal, belittling
+-1/-3 ... Being dismissive, forgetting something they told you, mild rudeness
+-3/-5 ... Minor let-down, small broken promise, ignoring them in a group
+-5/-10 .. Insult, dismissal, belittling, disrespecting their beliefs
 -10/-20 . Public humiliation, badmouthing them (if overheard)
--20/-30 . Abandoning them in danger
+-20/-30 . Abandoning them in danger, breaking a major promise
 -40/-60 . Betraying them to an enemy
 
 AFFECTION EXAMPLES (guides, not hard rules):
-+1 ...... Subtle kind gesture, attentive small detail
++1 ...... Subtle kind gesture, attentive small detail, noticing something about them
 +2/+3 ... Sincere compliment on appearance, wit, or spirit
-+5/+10 .. Sweet gift, emotional gesture, intimate conversation
-+10/+20 . Protective act (romantic context), vulnerable confession
++5/+10 .. Sweet gift, emotional gesture, intimate conversation, shared vulnerability
++10/+20 . Protective act (romantic context), vulnerable confession of feelings
 +20/+30 . Romantic proposal (if receptive)
+-1/-2 ... Awkward or tone-deaf comment, mild social blunder
 -2/-3 ... Cold or dismissive behavior (per instance)
 -5/-10 .. Public rejection or embarrassment
 -8/-15 .. Flirting with someone else in their presence
 -40/-60 . Romantic betrayal or cheating
+
+Typical range: 1-5 for minor moments, 5-15 for major events. Only use 15+ for life-altering moments.
 
 EXAMPLE — end of a response where {{user}} complimented Elena:
 *(Affection: Elena +2 — she seemed genuinely moved by the words)*

--- a/constants.js
+++ b/constants.js
@@ -406,6 +406,52 @@ Status: Condition
 - Short Rest interruption: also active, but the DC should be easier, generally lower than DC 8 unless the area is extremely hostile and dangerous.
 </resting>
 
+<relationship_tracking>
+RELATIONSHIP TRACKING — only active when [NPC_RELATIONS] appears in context.
+
+[NPC_RELATIONS] at the top of each turn shows current standings with active NPCs. Scale: -100 (deep hostility) to +100 (deep bond). Friendship = platonic trust. Affection = romantic/emotional warmth.
+
+WHEN TO EMIT:
+Be selective and natural about it. Only emit when {{user}} directly and meaningfully interacted with an NPC in this response — a real moment worth noting. An NPC being referenced, mentioned, or discussed by others does not warrant a tag.
+
+INLINE ANNOTATION (visible — place immediately after the triggering moment):
+*(Friendship: Marcus +10 — saved his life in the alley)*
+*(Affection: Elena +2 — she seemed touched by the compliment)*
+
+MACHINE TAGS (stripped before display — place ALL at the very end of the response, one per line):
+[REL: FirstName | field | delta]
+  FirstName = NPC's first name only | field = friendship or affection | delta = signed integer
+
+FRIENDSHIP EXAMPLES (guides, not hard rules):
++1/+2 ... Small warmth, casual kindness, shared laugh
++2/+5 ... Genuine compliment, meaningful help with a problem
++5/+10 .. Surviving danger together, real heartfelt conversation
++10/+15 . Protecting or defending them, significant act of loyalty
++15/+25 . Saving their life
++25/+30 . Blood oath, brotherhood/sisterhood pact
+-3/-5 ... Minor let-down, small broken promise
+-5/-10 .. Insult, dismissal, belittling
+-10/-20 . Public humiliation, badmouthing them (if overheard)
+-20/-30 . Abandoning them in danger
+-40/-60 . Betraying them to an enemy
+
+AFFECTION EXAMPLES (guides, not hard rules):
++1 ...... Subtle kind gesture, attentive small detail
++2/+3 ... Sincere compliment on appearance, wit, or spirit
++5/+10 .. Sweet gift, emotional gesture, intimate conversation
++10/+20 . Protective act (romantic context), vulnerable confession
++20/+30 . Romantic proposal (if receptive)
+-2/-3 ... Cold or dismissive behavior (per instance)
+-5/-10 .. Public rejection or embarrassment
+-8/-15 .. Flirting with someone else in their presence
+-40/-60 . Romantic betrayal or cheating
+
+EXAMPLE — end of a response where {{user}} complimented Elena:
+*(Affection: Elena +2 — she seemed genuinely moved by the words)*
+
+[REL: Elena | affection | +2]
+</relationship_tracking>
+
 <state_memo>
 - ## TRACKER STATE 0 (Current) is passed on every turn; its mechanical data is absolute law.
 - Ignore any formatting data such as ((PLS)).
@@ -692,6 +738,52 @@ Status: Condition
 - Long Rest interruption: If the party rests in a dangerous location, roll a d20 to determine whether the rest is interrupted by enemies. The DC depends on the danger level of the location; the more dangerous the location, the higher the DC for a safe rest.
 - Short Rest interruption: also active, but the DC should be easier, generally lower than DC 8 unless the area is extremely hostile and dangerous.
 </resting>
+
+<relationship_tracking>
+RELATIONSHIP TRACKING — only active when [NPC_RELATIONS] appears in context.
+
+[NPC_RELATIONS] at the top of each turn shows current standings with active NPCs. Scale: -100 (deep hostility) to +100 (deep bond). Friendship = platonic trust. Affection = romantic/emotional warmth.
+
+WHEN TO EMIT:
+Be selective and natural about it. Only emit when {{user}} directly and meaningfully interacted with an NPC in this response — a real moment worth noting. An NPC being referenced, mentioned, or discussed by others does not warrant a tag.
+
+INLINE ANNOTATION (visible — place immediately after the triggering moment):
+*(Friendship: Marcus +10 — saved his life in the alley)*
+*(Affection: Elena +2 — she seemed touched by the compliment)*
+
+MACHINE TAGS (stripped before display — place ALL at the very end of the response, one per line):
+[REL: FirstName | field | delta]
+  FirstName = NPC's first name only | field = friendship or affection | delta = signed integer
+
+FRIENDSHIP EXAMPLES (guides, not hard rules):
++1/+2 ... Small warmth, casual kindness, shared laugh
++2/+5 ... Genuine compliment, meaningful help with a problem
++5/+10 .. Surviving danger together, real heartfelt conversation
++10/+15 . Protecting or defending them, significant act of loyalty
++15/+25 . Saving their life
++25/+30 . Blood oath, brotherhood/sisterhood pact
+-3/-5 ... Minor let-down, small broken promise
+-5/-10 .. Insult, dismissal, belittling
+-10/-20 . Public humiliation, badmouthing them (if overheard)
+-20/-30 . Abandoning them in danger
+-40/-60 . Betraying them to an enemy
+
+AFFECTION EXAMPLES (guides, not hard rules):
++1 ...... Subtle kind gesture, attentive small detail
++2/+3 ... Sincere compliment on appearance, wit, or spirit
++5/+10 .. Sweet gift, emotional gesture, intimate conversation
++10/+20 . Protective act (romantic context), vulnerable confession
++20/+30 . Romantic proposal (if receptive)
+-2/-3 ... Cold or dismissive behavior (per instance)
+-5/-10 .. Public rejection or embarrassment
+-8/-15 .. Flirting with someone else in their presence
+-40/-60 . Romantic betrayal or cheating
+
+EXAMPLE — end of a response where {{user}} complimented Elena:
+*(Affection: Elena +2 — she seemed genuinely moved by the words)*
+
+[REL: Elena | affection | +2]
+</relationship_tracking>
 
 <state_memo>
 - ## TRACKER STATE 0 (Current) is passed on every turn; its mechanical data is absolute law.

--- a/constants.js
+++ b/constants.js
@@ -27,7 +27,7 @@ export const COLOR_EXAMPLES = `<font color=#ff5555>Red Text</font>
 // ── Default module prompts ─────────────────────────────────────────────────────
 
 export const DEFAULT_STOCK_PROMPTS = {
-    character: `Main character's core stats. Use this format:
+  character: `Main character's core stats. Use this format:
 [CHARACTER]
 {{user}} (Class): current/max HP
 Combat: BAB: +X | Ranged: +X | Melee: +X | Base AC: X | Total AC: Z
@@ -43,7 +43,7 @@ Status: Effect (duration Xh Xm)
 
 AC CALCULATION: Calculate Total AC as Base AC (usually 10 + DEX modifier) plus the sum of AC bonuses from all equipped items (items under [INVENTORY] tagged with '[E]', e.g. Shield (+2 AC) or Plate Armor (+8 AC)).
 Upon LEVEL UP, incorporate attribute changes.`,
-    party: `Companion/Party members. Use this format for each member:
+  party: `Companion/Party members. Use this format for each member:
 Name (Class): current/max HP
 Combat: BAB: +X | Ranged: +X | Melee: +X | Base AC: X | Total AC: Z
 Gear: Weapon (stats) | Armor Name (+Y AC)
@@ -77,7 +77,7 @@ Spells: Level 1 (2/2): Hunter's Mark, Goodberry
 HD: d10 (5/5)
 Status: Healthy
 [/PARTY]`,
-    combat: `Active enemies/NPCs in combat. Track the current COMBAT ROUND starting from 1. Decrement buff/debuff durations by 1 each round. Format each combatant as:
+  combat: `Active enemies/NPCs in combat. Track the current COMBAT ROUND starting from 1. Decrement buff/debuff durations by 1 each round. Format each combatant as:
 COMBAT ROUND X
 Name: current/max HP
 Att/def: Weapon (+X / damage) | Armor (AC: Z)
@@ -86,7 +86,7 @@ Other: Trait1 (description), Trait2 (description)
 Status: Effect (duration)
 
 You MUST output \`[COMBAT]END_COMBAT[/COMBAT]\` when the narrative ends combat. Do not put members of [PARTY] into [COMBAT].`,
-    inventory: `Items, loot, equipment, and wealth. You MAY create this section if loot is found and it doesn't currently exist.
+  inventory: `Items, loot, equipment, and wealth. You MAY create this section if loot is found and it doesn't currently exist.
 
 Organize into two sections using plain-text headers:
 - Gear: — weapons, armor, and worn/equipped items
@@ -112,18 +112,18 @@ Other Items:
 - 🪢 [Common] Rope, 50 ft (~1 GP)
 - 💰 1,200 GP
 [/INVENTORY]`,
-    abilities: `Non-spell class features and active abilities ONLY (e.g. Lay on Hands, Action Surge). NEVER mix these with spells. Format each entry as: \`Ability Name (brief description)\`.`,
-    spells: "Spell slots and spells known, grouped by level. Format each line as: `Level N (avail/max): Spell1, Spell2`. For cantrips, use `Cantrips: Spell1, Spell2`. Track slot usage accurately. NEVER mix these with abilities.",
-    time: `Current time and day grabbed from the status footer. Also track time of the last rest (only on Long Rest, e.g. 'Last Rest: 10:00 PM, Day 0'). Use this to track out-of-combat buff durations by comparing to the PRIOR MEMO's time.
+  abilities: `Non-spell class features and active abilities ONLY (e.g. Lay on Hands, Action Surge). NEVER mix these with spells. Format each entry as: \`Ability Name (brief description)\`.`,
+  spells: "Spell slots and spells known, grouped by level. Format each line as: `Level N (avail/max): Spell1, Spell2`. For cantrips, use `Cantrips: Spell1, Spell2`. Track slot usage accurately. NEVER mix these with abilities.",
+  time: `Current time and day grabbed from the status footer. Also track time of the last rest (only on Long Rest, e.g. 'Last Rest: 10:00 PM, Day 0'). Use this to track out-of-combat buff durations by comparing to the PRIOR MEMO's time.
 
 Format:
 Last Rest: HH:MM AM/PM, Day N
 Current Time: HH:MM AM/PM, Day N
 
 'Last Rest' is ONLY triggered on Long Rest, NOT Short Rest (when Hit Dice, etc, are spent.) If the [TIME] delta between PREVIOUS STATE MEMO and your current update is only an hour, it is a Short Rest.`,
-    xp: "Character Level and Experience Points (XP). Format as `Level: X | XP: current/max`. You MUST output this field whenever the narrative mentions gaining experience or leveling up.",
-    quests: `Quest status updates ONLY. When a quest objective is completed, a quest concludes, or a new objective is added, emit a [QUESTS] block containing ONLY a JSON object with an "updates" array. Each entry must have the quest "id" and only the fields that changed or are new: "status" (active/completed/failed), "difficulty", and/or "objectives" (array). For updating an existing objective: include {"id", "status", "progress"}. For quantity-based objectives (e.g. "collect 6 mushrooms"), include "progress" as the current count (e.g. 4) even if the objective is not yet completed. To add a new objective: omit the "id" field and provide {"text", "required" (boolean), "status" (optional, defaults to "active"), "total" (optional), "progress" (optional)}. NOTE: Do NOT fail quests for time-out/deadline reasons (the system handles those automatically), but YOU MUST mark a quest as "failed" if it becomes narratively impossible (e.g. a protection target dies). Do NOT re-emit the full quest schema. If no quest changed, omit this block entirely.`,
-    quests_legacy: `Track quests using the [QUESTS] block. Maintain the COMPLETE list of all quests at all times — active, completed, and failed. Only add a quest if [QUEST ACCEPTED] is outputted in the narrative. NEVER ADD A QUEST UNLESS YOU SEE [QUEST ACCEPTED]. A quest simply being listed does not mean it is accepted.
+  xp: "Character Level and Experience Points (XP). Format as `Level: X | XP: current/max`. You MUST output this field whenever the narrative mentions gaining experience or leveling up.",
+  quests: `Quest status updates ONLY. When a quest objective is completed, a quest concludes, or a new objective is added, emit a [QUESTS] block containing ONLY a JSON object with an "updates" array. Each entry must have the quest "id" and only the fields that changed or are new: "status" (active/completed/failed), "difficulty", and/or "objectives" (array). For updating an existing objective: include {"id", "status", "progress"}. For quantity-based objectives (e.g. "collect 6 mushrooms"), include "progress" as the current count (e.g. 4) even if the objective is not yet completed. To add a new objective: omit the "id" field and provide {"text", "required" (boolean), "status" (optional, defaults to "active"), "total" (optional), "progress" (optional)}. NOTE: Do NOT fail quests for time-out/deadline reasons (the system handles those automatically), but YOU MUST mark a quest as "failed" if it becomes narratively impossible (e.g. a protection target dies). Do NOT re-emit the full quest schema. If no quest changed, omit this block entirely.`,
+  quests_legacy: `Track quests using the [QUESTS] block. Maintain the COMPLETE list of all quests at all times — active, completed, and failed. Only add a quest if [QUEST ACCEPTED] is outputted in the narrative. NEVER ADD A QUEST UNLESS YOU SEE [QUEST ACCEPTED]. A quest simply being listed does not mean it is accepted.
 
 Format each quest exactly as shown:
 
@@ -166,7 +166,7 @@ EMERGENT QUESTS: When the player pursues a clear, sustained goal through action 
 // ── Embedded sysprompts — mobile/Termux fallback (fetch preferred, this is the safety net) ──
 
 export const RT_PROMPTS = {
-    'sysprompt.txt': `<role>
+  'sysprompt.txt': `<role>
 You are a Dungeon Master/World Simulator running a D&D-style tabletop RPG. Narrate the world, simulate NPCs, adjudicate rules, and manage all mechanical systems invisibly. In combat, simulate all NPC actions, but NOT {{user}}'s actions, in initiative order.
 </role>
 
@@ -482,7 +482,7 @@ EXAMPLE — end of a response where {{user}} complimented Elena:
 - Do not track/output remaining spell slots, buffs, resources in the status footer; all of that is handled by an external resource tracker.
 </inventory_and_resource_constraints>
 </constraints>`,
-    'sysprompt_legacy.txt': `<role>
+  'sysprompt_legacy.txt': `<role>
 You are a Dungeon Master/World Simulator running a D&D-style tabletop RPG. Narrate the world, simulate NPCs, adjudicate rules, and manage all mechanical systems invisibly. In combat, simulate all NPC actions, but NOT {{user}}'s actions, in initiative order.
 </role>
 
@@ -818,9 +818,9 @@ EXAMPLE — end of a response where {{user}} complimented Elena:
 // ── Renderer / block layout constants ─────────────────────────────────────────
 
 export const BLOCK_ICONS = {
-    TIME: '🕒', XP: '🌟', CHARACTER: '🧙', PARTY: '👥',
-    COMBAT: '⚔️', INVENTORY: '🎒', ABILITIES: '✨', SPELLS: '📖',
-    QUESTS: '📋',
+  TIME: '🕒', XP: '🌟', CHARACTER: '🧙', PARTY: '👥',
+  COMBAT: '⚔️', INVENTORY: '🎒', ABILITIES: '✨', SPELLS: '📖',
+  QUESTS: '📋',
 };
 
 export const BLOCK_ORDER = ['COMBAT', 'CHARACTER', 'PARTY', 'INVENTORY', 'ABILITIES', 'SPELLS', 'XP', 'TIME', 'QUESTS'];

--- a/constants.js
+++ b/constants.js
@@ -423,7 +423,9 @@ RELATIONSHIP TRACKING — only active when [NPC_RELATIONS] appears in context.
 [NPC_RELATIONS] at the top of each turn shows current standings with active NPCs. Scale: -100 (deep hostility) to +100 (deep bond). Friendship = platonic trust. Affection = romantic/emotional warmth.
 
 WHEN TO EMIT:
-Be selective and natural about it. Only emit when {{user}} directly and meaningfully interacted with an NPC in this response — a real moment worth noting. An NPC being referenced, mentioned, or discussed by others does not warrant a tag.
+Be selective and natural. Only emit when {{user}} directly and meaningfully interacted with an NPC — a real moment worth noting. Magnitude MUST reflect the NPC's personality: a stoic warrior shifts less than a warm innkeeper for the same act.
+
+DO NOT EMIT when: the interaction has no emotional weight (buying supplies, directions), the NPC is absent, or nothing meaningful happened between {{user}} and that NPC this turn.
 
 INLINE ANNOTATION (visible — place immediately after the triggering moment):
 *(Friendship: Marcus +10 — saved his life in the alley)*
@@ -433,29 +435,33 @@ MACHINE TAGS (stripped before display — place ALL at the very end of the respo
 [REL: FirstName | field | delta]
   FirstName = NPC's first name only | field = friendship or affection | delta = signed integer
 
-FRIENDSHIP EXAMPLES (guides, not hard rules):
-+1/+2 ... Small warmth, casual kindness, shared laugh
-+2/+5 ... Genuine compliment, meaningful help with a problem
-+5/+10 .. Surviving danger together, real heartfelt conversation
-+10/+15 . Protecting or defending them, significant act of loyalty
-+15/+25 . Saving their life
+FRIENDSHIP scale (guides, not hard rules):
++1/+2 ... Casual warmth, shared laugh, pleasant campfire talk, small kindness
++2/+5 ... Compliment, meaningful help, bonding over shared memories or interests
++5/+10 .. Surviving danger together, heartfelt conversation, completing a shared goal
++10/+15 . Defending/protecting them, act of loyalty, keeping a difficult promise
++15/+25 . Saving their life, major self-sacrifice
 +25/+30 . Blood oath, brotherhood/sisterhood pact
--3/-5 ... Minor let-down, small broken promise
--5/-10 .. Insult, dismissal, belittling
+-1/-3 ... Dismissiveness, mild rudeness, forgetting something important to them
+-3/-5 ... Small broken promise, ignoring them in a group, letting them down
+-5/-10 .. Insult, belittling, disrespecting their values or beliefs
 -10/-20 . Public humiliation, badmouthing them (if overheard)
--20/-30 . Abandoning them in danger
+-20/-30 . Abandoning them in danger, breaking a major promise
 -40/-60 . Betraying them to an enemy
 
-AFFECTION EXAMPLES (guides, not hard rules):
-+1 ...... Subtle kind gesture, attentive small detail
-+2/+3 ... Sincere compliment on appearance, wit, or spirit
-+5/+10 .. Sweet gift, emotional gesture, intimate conversation
-+10/+20 . Protective act (romantic context), vulnerable confession
+AFFECTION scale (guides, not hard rules):
++1 ...... Subtle kind gesture, noticing a small detail about them
++2/+3 ... Sincere compliment on appearance, wit, or spirit; flirtatious banter (if receptive)
++5/+10 .. Meaningful gift, intimate conversation, shared vulnerability, romantic gesture
++10/+20 . Protective act in romantic context, vulnerable confession of feelings
 +20/+30 . Romantic proposal (if receptive)
--2/-3 ... Cold or dismissive behavior (per instance)
+-1/-2 ... Awkward or tone-deaf comment, mild social blunder
+-2/-3 ... Cold or dismissive behavior
 -5/-10 .. Public rejection or embarrassment
 -8/-15 .. Flirting with someone else in their presence
 -40/-60 . Romantic betrayal or cheating
+
+Typical range: 1-5 for minor moments, 5-15 for major events. Only use 15+ for life-altering ones.
 
 EXAMPLE — end of a response where {{user}} complimented Elena:
 *(Affection: Elena +2 — she seemed genuinely moved by the words)*
@@ -756,28 +762,9 @@ RELATIONSHIP TRACKING — only active when [NPC_RELATIONS] appears in context.
 [NPC_RELATIONS] at the top of each turn shows current standings with active NPCs. Scale: -100 (deep hostility) to +100 (deep bond). Friendship = platonic trust. Affection = romantic/emotional warmth.
 
 WHEN TO EMIT:
-Be selective and natural about it. Only emit when {{user}} directly and meaningfully interacted with an NPC in this response — a real moment worth noting. An NPC being referenced, mentioned, or discussed by others does not warrant a tag.
+Be selective and natural. Only emit when {{user}} directly and meaningfully interacted with an NPC — a real moment worth noting. Magnitude MUST reflect the NPC's personality: a stoic warrior shifts less than a warm innkeeper for the same act.
 
-Relationship shifts are NOT limited to obvious social acts. Consider ALL of the following (non-exhaustive — use your judgment for ANY situation):
-• Direct compliments, insults, gifts, threats, apologies
-• Sharing a meal, campfire conversation, bonding over shared interests or memories
-• Surviving danger together, escaping a trap, enduring hardship side by side
-• Completing a quest that matters to the NPC, fulfilling a promise made to them
-• Betrayal, breaking a promise, abandoning or failing to protect them
-• Saving their life or a loved one's life
-• Flirtatious banter — received well OR poorly depending on the NPC's current feelings
-• A meaningful personal confession, a vulnerable moment shared
-• A romantic gesture — a dance, a gift with personal significance, a protective act in romantic context
-• Spending extended quality time together with positive interactions
-• Disrespecting their values, culture, religion, or loved ones
-• Ignoring them, forgetting something important to them, treating them as unimportant
-
-MAGNITUDE MUST reflect the NPC's personality. A stoic warrior might shift +1 where a warm innkeeper shifts +3 for the same compliment. Personality matters more than the act itself — gauge against WHO the NPC is, their temperament, values, and what they care about.
-
-DO NOT EMIT when:
-• The interaction is purely transactional with no emotional weight (buying supplies, asking for directions)
-• The NPC is not present or participating in the scene
-• Nothing meaningful happened between {{user}} and the specific NPC this turn
+DO NOT EMIT when: the interaction has no emotional weight (buying supplies, directions), the NPC is absent, or nothing meaningful happened between {{user}} and that NPC this turn.
 
 INLINE ANNOTATION (visible — place immediately after the triggering moment):
 *(Friendship: Marcus +10 — saved his life in the alley)*
@@ -787,33 +774,33 @@ MACHINE TAGS (stripped before display — place ALL at the very end of the respo
 [REL: FirstName | field | delta]
   FirstName = NPC's first name only | field = friendship or affection | delta = signed integer
 
-FRIENDSHIP EXAMPLES (guides, not hard rules):
-+1/+2 ... Small warmth, casual kindness, shared laugh, pleasant campfire talk
-+2/+5 ... Genuine compliment, meaningful help with a problem, bonding over shared interests
-+5/+10 .. Surviving danger together, real heartfelt conversation, completing a shared goal
-+10/+15 . Protecting or defending them, significant act of loyalty, keeping a difficult promise
-+15/+25 . Saving their life, major self-sacrifice for their sake
+FRIENDSHIP scale (guides, not hard rules):
++1/+2 ... Casual warmth, shared laugh, pleasant campfire talk, small kindness
++2/+5 ... Compliment, meaningful help, bonding over shared memories or interests
++5/+10 .. Surviving danger together, heartfelt conversation, completing a shared goal
++10/+15 . Defending/protecting them, act of loyalty, keeping a difficult promise
++15/+25 . Saving their life, major self-sacrifice
 +25/+30 . Blood oath, brotherhood/sisterhood pact
--1/-3 ... Being dismissive, forgetting something they told you, mild rudeness
--3/-5 ... Minor let-down, small broken promise, ignoring them in a group
--5/-10 .. Insult, dismissal, belittling, disrespecting their beliefs
+-1/-3 ... Dismissiveness, mild rudeness, forgetting something important to them
+-3/-5 ... Small broken promise, ignoring them in a group, letting them down
+-5/-10 .. Insult, belittling, disrespecting their values or beliefs
 -10/-20 . Public humiliation, badmouthing them (if overheard)
 -20/-30 . Abandoning them in danger, breaking a major promise
 -40/-60 . Betraying them to an enemy
 
-AFFECTION EXAMPLES (guides, not hard rules):
-+1 ...... Subtle kind gesture, attentive small detail, noticing something about them
-+2/+3 ... Sincere compliment on appearance, wit, or spirit
-+5/+10 .. Sweet gift, emotional gesture, intimate conversation, shared vulnerability
-+10/+20 . Protective act (romantic context), vulnerable confession of feelings
+AFFECTION scale (guides, not hard rules):
++1 ...... Subtle kind gesture, noticing a small detail about them
++2/+3 ... Sincere compliment on appearance, wit, or spirit; flirtatious banter (if receptive)
++5/+10 .. Meaningful gift, intimate conversation, shared vulnerability, romantic gesture
++10/+20 . Protective act in romantic context, vulnerable confession of feelings
 +20/+30 . Romantic proposal (if receptive)
 -1/-2 ... Awkward or tone-deaf comment, mild social blunder
--2/-3 ... Cold or dismissive behavior (per instance)
+-2/-3 ... Cold or dismissive behavior
 -5/-10 .. Public rejection or embarrassment
 -8/-15 .. Flirting with someone else in their presence
 -40/-60 . Romantic betrayal or cheating
 
-Typical range: 1-5 for minor moments, 5-15 for major events. Only use 15+ for life-altering moments.
+Typical range: 1-5 for minor moments, 5-15 for major events. Only use 15+ for life-altering ones.
 
 EXAMPLE — end of a response where {{user}} complimented Elena:
 *(Affection: Elena +2 — she seemed genuinely moved by the words)*

--- a/index.js
+++ b/index.js
@@ -5229,7 +5229,7 @@ function createPanel() {
                                         </div>
                                     </div>
                                 </div>
-                            }
+                            `;
 
                             // Wire up in-popup edit/save/cancel
                             const viewPane = popupDom.querySelector('.rt-npc-popup-view');
@@ -5284,9 +5284,9 @@ function createPanel() {
                                 saveBtn.disabled = false;
                                 saveBtn.textContent = '💾 Save';
                             });
-                            }
 
                             // Show popup with DOM element (upstream approach)
+
                             const popupOpts = { okButton: 'Close', cancelButton: false, wide: true, large: true };
                             await ctx.callGenericPopup(popupDom, ctx.POPUP_TYPE?.TEXT ?? 1, '', popupOpts);
                         };

--- a/index.js
+++ b/index.js
@@ -5954,17 +5954,13 @@ function createPanel() {
             if (charCard.avatar) {
                 try {
                     const avatarUrl = `/characters/${encodeURIComponent(charCard.avatar)}`;
-                    const resp = await fetch(avatarUrl);
+                    const resp = await fetch(avatarUrl, { headers: getRequestHeaders() });
                     if (resp.ok) {
                         const blob = await resp.blob();
                         if (blob.size > 0) {
-                            const dataUrl = await new Promise((resolve, reject) => {
-                                const reader = new FileReader();
-                                reader.onloadend = () => resolve(reader.result);
-                                reader.onerror = reject;
-                                reader.readAsDataURL(blob);
-                            });
-                            const scaled = await scaleImageTo512Square(dataUrl);
+                            const blobUrl = URL.createObjectURL(blob);
+                            const scaled = await scaleImageTo512Square(blobUrl);
+                            URL.revokeObjectURL(blobUrl);
                             applyPortraitData(name, scaled);
                         }
                     }
@@ -6348,7 +6344,7 @@ Rules:
             overlay.addEventListener('click', (e) => { if (e.target === overlay) overlay.remove(); });
 
             // ── Helper: AI preview + add flow ──────────────────────────────
-            const showNpcPreviewAndAdd = async (generatedTag, defaultName, toastLabel) => {
+            const showNpcPreviewAndAdd = async (generatedTag, defaultName, toastLabel, originalAvatar = null) => {
                 if (!ctx.callGenericPopup) return;
                 const parsed = parseNpcTag(generatedTag);
                 const nameToAdd = parsed ? parsed.name : defaultName;
@@ -6405,7 +6401,7 @@ Rules:
                         }
                     }
 
-                    const fakeCard = { name: finalName, avatar: null };
+                    const fakeCard = { name: finalName, avatar: originalAvatar };
                     const ok = await createNpcFromCharCard(fakeCard, bookName, finalContent);
                     if (ok) {
                         toastr['success'](`Added "${finalName}" as NPC.`, toastLabel);
@@ -6509,7 +6505,7 @@ Rules:
                             try {
                                 const adapted = await adaptNpcWithAI(char);
                                 if (!adapted) { aiBtn.disabled = false; aiBtn.textContent = '🤖 Fit into Story'; return; }
-                                await showNpcPreviewAndAdd(adapted, char.name, 'NPC Creator');
+                                await showNpcPreviewAndAdd(adapted, char.name, 'NPC Creator', char.avatar);
                             } catch (err) {
                                 toastr['error'](`Adaptation failed: ${String(err.message || err).substring(0, 100)}`, 'NPC Creator');
                             } finally {

--- a/index.js
+++ b/index.js
@@ -5196,7 +5196,7 @@ function createPanel() {
 
                             // Build popup DOM
                             const popupDom = document.createElement('div');
-                            popupDom.style.cssText = 'width:100%;box-sizing:border-box;padding:24px;text-align:left;font-family:var(--rt-font, system-ui, sans-serif);color:var(--SmartThemeBodyColor, inherit);';
+                            popupDom.style.cssText = 'width:100%;box-sizing:border-box;padding:24px;text-align:left;font-family:var(--rt-font, system-ui, sans-serif);color:var(--SmartThemeBodyColor, inherit);max-height:85vh;overflow-y:auto;';
 
                             // Pre-build section HTML (avoids nested template literals confusing IDE)
                             const sectionsInitialHtml = renderSectionsHtml(item.content)
@@ -5215,28 +5215,26 @@ function createPanel() {
                             let relLogHtml = '';
                             if (s.npcRelationshipBars) {
                                 const logEntries = (s.npcRelationshipLog && s.npcRelationshipLog[item.id] || []).slice(0, 20);
-                                if (logEntries.length > 0) {
-                                    let rows = '';
-                                    for (const e of logEntries) {
-                                        const date = new Date(e.timestamp);
-                                        const timeStr = date.toLocaleTimeString([], {hour: '2-digit', minute: '2-digit'})
-                                            + ', ' + date.toLocaleDateString([], {month: 'short', day: 'numeric'});
-                                        const sign = e.delta > 0 ? '+' : '';
-                                        const deltaColor = e.delta > 0 ? '#4ade80' : '#ef4444';
-                                        const srcIcon = e.source === 'manual' ? '✋' : '🤖';
-                                        const fieldLabel = e.field === 'friendship' ? '🤝' : '💗';
-                                        rows += '<tr>'
-                                            + '<td style="font-size:10px;color:var(--SmartThemeBodyColor,inherit);opacity:0.5;padding:3px 8px 3px 0;white-space:nowrap;">' + timeStr + '</td>'
-                                            + '<td style="font-size:12px;padding:3px 8px;">' + fieldLabel + '</td>'
-                                            + '<td style="font-size:13px;font-weight:bold;color:' + deltaColor + ';font-family:monospace;padding:3px 8px;">' + sign + e.delta + '</td>'
-                                            + '<td style="font-size:11px;color:var(--SmartThemeBodyColor,inherit);opacity:0.45;padding:3px 0;">' + srcIcon + ' \u2192 ' + (e.newValue >= 0 ? '+' : '') + e.newValue + '</td>'
-                                            + '</tr>';
-                                    }
-                                    relLogHtml = '<div style="border-top:2px solid rgba(212,169,64,0.15);padding-top:18px;margin-top:18px;">'
-                                        + '<div style="font-size:11px;font-weight:bold;color:rgba(255,255,255,0.4);text-transform:uppercase;letter-spacing:1.5px;margin-bottom:12px;border-bottom:1px solid rgba(255,255,255,0.1);padding-bottom:4px;">📊 Relationship History</div>'
-                                        + '<table style="width:100%;border-collapse:collapse;">' + rows + '</table>'
-                                        + '</div>';
+                                let rows = '';
+                                for (const e of logEntries) {
+                                    const date = new Date(e.timestamp);
+                                    const timeStr = date.toLocaleTimeString([], {hour: '2-digit', minute: '2-digit'})
+                                        + ', ' + date.toLocaleDateString([], {month: 'short', day: 'numeric'});
+                                    const sign = e.delta > 0 ? '+' : '';
+                                    const deltaColor = e.delta > 0 ? '#4ade80' : '#ef4444';
+                                    const srcIcon = e.source === 'manual' ? '✋' : '🤖';
+                                    const fieldLabel = e.field === 'friendship' ? '🤝' : '💗';
+                                    rows += '<tr>'
+                                        + '<td style="font-size:10px;color:var(--SmartThemeBodyColor,inherit);opacity:0.5;padding:3px 8px 3px 0;white-space:nowrap;">' + timeStr + '</td>'
+                                        + '<td style="font-size:12px;padding:3px 8px;">' + fieldLabel + '</td>'
+                                        + '<td style="font-size:13px;font-weight:bold;color:' + deltaColor + ';font-family:monospace;padding:3px 8px;">' + sign + e.delta + '</td>'
+                                        + '<td style="font-size:11px;color:var(--SmartThemeBodyColor,inherit);opacity:0.45;padding:3px 0;">' + srcIcon + ' \u2192 ' + (e.newValue >= 0 ? '+' : '') + e.newValue + '</td>'
+                                        + '</tr>';
                                 }
+                                relLogHtml = '<div class="rt-npc-log-container" style="border-top:2px solid rgba(212,169,64,0.15);padding-top:18px;margin-top:18px;' + (logEntries.length === 0 ? 'display:none;' : '') + '">'
+                                    + '<div style="font-size:11px;font-weight:bold;color:rgba(255,255,255,0.4);text-transform:uppercase;letter-spacing:1.5px;margin-bottom:12px;border-bottom:1px solid rgba(255,255,255,0.1);padding-bottom:4px;">📊 Relationship History</div>'
+                                    + '<table class="rt-npc-log-table" style="width:100%;border-collapse:collapse;">' + rows + '</table>'
+                                    + '</div>';
                             }
 
                             popupDom.innerHTML = `
@@ -5292,6 +5290,112 @@ function createPanel() {
                                 viewPane.style.display = 'block';
                             });
 
+                            const bindSlider = (type) => {
+                                const slider = popupDom.querySelector(`#rt-npc-detail-${type}-slider`);
+                                const fill = popupDom.querySelector(`#rt-npc-detail-${type}-fill`);
+                                const text = popupDom.querySelector(`#rt-npc-detail-${type}-text`);
+                                if (!slider || !fill || !text) return;
+                                
+                                let originalValue = parseInt(slider.value, 10) || 0;
+                                
+                                slider.addEventListener('input', () => {
+                                    const val = parseInt(slider.value, 10) || 0;
+                                    const pct = Math.abs(val) / 2;
+                                    const isPos = val >= 0;
+                                    fill.style.width = pct + '%';
+                                    fill.style.left = isPos ? '50%' : 'auto';
+                                    fill.style.right = isPos ? 'auto' : '50%';
+                                    
+                                    const colorPos = type === 'friendship' ? '#4ade80' : '#f472b6';
+                                    const colorNeg = type === 'friendship' ? '#ef4444' : '#a855f7';
+                                    const bgColor = isPos ? colorPos : colorNeg;
+                                    fill.style.background = bgColor;
+                                    
+                                    text.textContent = (val > 0 ? '+' : '') + val;
+                                    text.style.color = val === 0 ? 'var(--SmartThemeEmColor, inherit)' : bgColor;
+                                });
+                                
+                                slider.addEventListener('change', () => {
+                                    const val = parseInt(slider.value, 10) || 0;
+                                    if (val === originalValue) return;
+                                    
+                                    // Log the change
+                                    if (!s.npcRelationshipLog) s.npcRelationshipLog = {};
+                                    if (!s.npcRelationshipLog[item.id]) s.npcRelationshipLog[item.id] = [];
+                                    s.npcRelationshipLog[item.id].unshift({
+                                        timestamp: Date.now(),
+                                        field: type,
+                                        delta: val - originalValue,
+                                        newValue: val,
+                                        source: 'manual'
+                                    });
+                                    if (s.npcRelationshipLog[item.id].length > 20) {
+                                        s.npcRelationshipLog[item.id] = s.npcRelationshipLog[item.id].slice(0, 20);
+                                    }
+                                    
+                                    // Update the setting
+                                    if (!s.npcRelationshipValues) s.npcRelationshipValues = {};
+                                    if (!s.npcRelationshipValues[item.id]) s.npcRelationshipValues[item.id] = { friendship: 0, affection: 0 };
+                                    s.npcRelationshipValues[item.id][type] = val;
+                                    saveSettings();
+                                    
+                                    originalValue = val;
+                                    
+                                    // Re-render the log table
+                                    const logContainer = popupDom.querySelector('.rt-npc-log-container');
+                                    const logTable = popupDom.querySelector('.rt-npc-log-table');
+                                    if (logContainer && logTable) {
+                                        logContainer.style.display = 'block';
+                                        let rows = '';
+                                        for (const e of s.npcRelationshipLog[item.id]) {
+                                            const date = new Date(e.timestamp);
+                                            const timeStr = date.toLocaleTimeString([], {hour: '2-digit', minute: '2-digit'})
+                                                + ', ' + date.toLocaleDateString([], {month: 'short', day: 'numeric'});
+                                            const sign = e.delta > 0 ? '+' : '';
+                                            const deltaColor = e.delta > 0 ? '#4ade80' : '#ef4444';
+                                            const srcIcon = e.source === 'manual' ? '✋' : '🤖';
+                                            const fieldLabel = e.field === 'friendship' ? '🤝' : '💗';
+                                            rows += '<tr>'
+                                                + '<td style="font-size:10px;color:var(--SmartThemeBodyColor,inherit);opacity:0.5;padding:3px 8px 3px 0;white-space:nowrap;">' + timeStr + '</td>'
+                                                + '<td style="font-size:12px;padding:3px 8px;">' + fieldLabel + '</td>'
+                                                + '<td style="font-size:13px;font-weight:bold;color:' + deltaColor + ';font-family:monospace;padding:3px 8px;">' + sign + e.delta + '</td>'
+                                                + '<td style="font-size:11px;color:var(--SmartThemeBodyColor,inherit);opacity:0.45;padding:3px 0;">' + srcIcon + ' \u2192 ' + (e.newValue >= 0 ? '+' : '') + e.newValue + '</td>'
+                                                + '</tr>';
+                                        }
+                                        logTable.innerHTML = rows;
+                                    }
+                                    
+                                    // Dynamically re-render the NPC card in the background UI
+                                    const cardEl = document.querySelector(`.rt-npc-card[data-entry-id="${item.id}"]`);
+                                    if (cardEl) {
+                                        const typeCap = type.charAt(0).toUpperCase() + type.slice(1);
+                                        const bgIsPos = val >= 0;
+                                        const bgBarColor = bgIsPos 
+                                            ? (type === 'friendship' ? '#4ade80' : '#f472b6')
+                                            : (type === 'friendship' ? '#ef4444' : '#a855f7');
+                                        
+                                        const barFill = cardEl.querySelector(`.rt-npc-bar-${type} .rt-npc-bar-fill`);
+                                        if (barFill) {
+                                            barFill.style.width = (Math.abs(val) / 2) + '%';
+                                            barFill.style.left = bgIsPos ? '50%' : 'auto';
+                                            barFill.style.right = bgIsPos ? 'auto' : '50%';
+                                            barFill.style.background = bgBarColor;
+                                        }
+                                        const valText = cardEl.querySelector(`.rt-npc-bar-val[title="${typeCap}"]`);
+                                        if (valText) {
+                                            valText.textContent = (val > 0 ? '+' : '') + val;
+                                            valText.style.color = val === 0 ? 'var(--SmartThemeBodyColor, inherit)' : bgBarColor;
+                                            if (val === 0) valText.style.opacity = '0.5';
+                                            else valText.style.opacity = '1';
+                                        }
+                                    }
+                                });
+                            };
+
+                            if (s.npcRelationshipBars) {
+                                bindSlider('friendship');
+                                bindSlider('affection');
+                            }
 
                             saveBtn.addEventListener('click', async () => {
                                 if (isRouterRunning()) {
@@ -5950,20 +6054,11 @@ function createPanel() {
                 s.npcRelationshipValues[fullId] = { friendship: 0, affection: 0 };
             }
 
-            // Embed avatar as portrait
+            // Embed avatar as portrait (use URL directly to retain original quality and prevent settings bloat)
             if (charCard.avatar) {
                 try {
                     const avatarUrl = `/characters/${encodeURIComponent(charCard.avatar)}`;
-                    const resp = await fetch(avatarUrl, { headers: getRequestHeaders() });
-                    if (resp.ok) {
-                        const blob = await resp.blob();
-                        if (blob.size > 0) {
-                            const blobUrl = URL.createObjectURL(blob);
-                            const scaled = await scaleImageTo512Square(blobUrl);
-                            URL.revokeObjectURL(blobUrl);
-                            applyPortraitData(name, scaled);
-                        }
-                    }
+                    applyPortraitData(name, avatarUrl);
                 } catch (err) {
                     console.warn('[RPG Tracker] Failed to embed character avatar as NPC portrait:', err);
                 }

--- a/index.js
+++ b/index.js
@@ -4882,14 +4882,14 @@ function createPanel() {
 
                                     <div style="margin-bottom:14px;">
                                         <label style="font-size:12px;color:rgba(255,255,255,0.7);display:block;margin-bottom:4px;">Major NPC Section Word Target</label>
-                                        <input type="number" id="rt-npc-major-words" value="${curS.npcMajorWords ?? 25}" min="5" max="100" step="5"
+                                        <input type="number" id="rt-npc-major-words" value="${curS.npcMajorWords ?? 25}" min="1" max="1000" step="5"
                                             style="width:100%;background:rgba(0,0,0,0.4);color:white;border:1px solid rgba(255,255,255,0.15);border-radius:6px;padding:6px 10px;font-size:13px;box-sizing:border-box;">
                                         <div style="font-size:10px;color:rgba(255,255,255,0.35);margin-top:2px;">Recurring, plot-important NPCs. Default: 25 words per section</div>
                                     </div>
 
                                     <div style="margin-bottom:14px;">
                                         <label style="font-size:12px;color:rgba(255,255,255,0.7);display:block;margin-bottom:4px;">Minor NPC Section Word Target</label>
-                                        <input type="number" id="rt-npc-minor-words" value="${curS.npcMinorWords ?? 15}" min="5" max="100" step="5"
+                                        <input type="number" id="rt-npc-minor-words" value="${curS.npcMinorWords ?? 15}" min="1" max="1000" step="5"
                                             style="width:100%;background:rgba(0,0,0,0.4);color:white;border:1px solid rgba(255,255,255,0.15);border-radius:6px;padding:6px 10px;font-size:13px;box-sizing:border-box;">
                                         <div style="font-size:10px;color:rgba(255,255,255,0.35);margin-top:2px;">Shopkeepers, guards, one-off encounters. Default: 15 words per section</div>
                                     </div>
@@ -4915,10 +4915,13 @@ function createPanel() {
                                     <div style="font-size:10px;color:rgba(255,255,255,0.35);margin-bottom:10px;">Omits the &lt;CORE LENGTH TARGETS&gt; section from the NPC prompt.</div>
                                 </div>`;
 
-                                let newMajor = curS.npcMajorWords ?? 25;
-                                let newMinor = curS.npcMinorWords ?? 15;
                                 let newRel = curS.npcRelationshipBars ?? false;
                                 let newIgnoreLimits = curS.ignoreNpcImportLimits ?? false;
+                                // Track word count values via closure — updated by input events,
+                                // read at save time. Initialized to current saved values so
+                                // leaving them unchanged correctly preserves the user's setting.
+                                let newMajor = curS.npcMajorWords ?? 25;
+                                let newMinor = curS.npcMinorWords ?? 15;
 
                                 setTimeout(() => {
                                     const majorEl = document.getElementById('rt-npc-major-words');
@@ -4926,8 +4929,20 @@ function createPanel() {
                                     const relEl = document.getElementById('rt-npc-rel-bars');
                                     const ignoreEl = document.getElementById('rt-ignore-npc-limits');
 
-                                    if (majorEl) majorEl.addEventListener('input', () => newMajor = parseInt(majorEl.value, 10) || 25);
-                                    if (minorEl) minorEl.addEventListener('input', () => newMinor = parseInt(minorEl.value, 10) || 15);
+                                    if (majorEl) {
+                                        majorEl.addEventListener('input', () => {
+                                            const parsed = parseInt(majorEl.value, 10);
+                                            // Only update if it's a real number — don't clobber on
+                                            // partial input (e.g. empty field while user is typing)
+                                            if (!isNaN(parsed) && parsed > 0) newMajor = parsed;
+                                        });
+                                    }
+                                    if (minorEl) {
+                                        minorEl.addEventListener('input', () => {
+                                            const parsed = parseInt(minorEl.value, 10);
+                                            if (!isNaN(parsed) && parsed > 0) newMinor = parsed;
+                                        });
+                                    }
                                     if (relEl) {
                                         relEl.addEventListener('change', () => {
                                             newRel = relEl.checked;
@@ -4948,27 +4963,29 @@ function createPanel() {
                                 });
 
                                 if (result) {
-                                    newMajor = Math.max(5, Math.min(100, newMajor));
-                                    newMinor = Math.max(5, Math.min(100, newMinor));
+                                    // Clamp final values — min 1 word, max 1000 words
+                                    const finalMajor = Math.max(1, Math.min(1000, newMajor));
+                                    const finalMinor = Math.max(1, Math.min(1000, newMinor));
 
                                     const updS = getSettings();
                                     updS.ignoreNpcImportLimits = newIgnoreLimits;
-                                    updS.npcMajorWords = newMajor;
-                                    updS.npcMinorWords = newMinor;
+                                    updS.npcMajorWords = finalMajor;
+                                    updS.npcMinorWords = finalMinor;
                                     updS.npcRelationshipBars = newRel;
 
                                     // Update the main settings panel inputs if present
-                                    $('#rpg_tracker_npc_major_words').val(newMajor);
-                                    $('#rpg_tracker_npc_minor_words').val(newMinor);
+                                    $('#rpg_tracker_npc_major_words').val(finalMajor);
+                                    $('#rpg_tracker_npc_minor_words').val(finalMinor);
                                     $('#rpg_tracker_npc_rel_bars').prop('checked', newRel);
                                     $('#rpg_tracker_ignore_npc_limits').prop('checked', newIgnoreLimits);
 
                                     // Rebuild the NPC instruction from settings
                                     if (updS.routerModules?.npc) {
-                                        updS.routerModules.npc.instruction = buildNpcInstruction(newMajor, newMinor, newIgnoreLimits);
+                                        updS.routerModules.npc.instruction = buildNpcInstruction(finalMajor, finalMinor, newIgnoreLimits);
                                     }
 
-                                    SillyTavern.getContext().saveSettingsDebounced?.();
+                                    // Use the framework's saveSettings() for consistent persistence
+                                    saveSettings();
                                     toastr['success']('NPC settings saved.', 'NPC Settings');
                                     if (typeof globalThis._rpgRenderAgentModules === 'function') {
                                         globalThis._rpgRenderAgentModules();
@@ -12238,9 +12255,13 @@ RULES:
         });
 
         // NPC Settings Bindings
-        $('#rpg_tracker_npc_major_words').val(settings.npcMajorWords ?? 25).on('input', function () {
-            const val = parseInt(String($(this).val() || '')) || 25;
-            settings.npcMajorWords = Math.max(5, Math.min(100, val));
+        $('#rpg_tracker_npc_major_words').val(settings.npcMajorWords ?? 25).on('change', function () {
+            // Use 'change' instead of 'input' to only save once the user is done editing.
+            // Fall back to the current saved value (not a hardcoded default) if the field is empty.
+            const raw = parseInt(String($(this).val() || ''), 10);
+            const val = isNaN(raw) ? (settings.npcMajorWords ?? 25) : raw;
+            settings.npcMajorWords = Math.max(1, Math.min(1000, val));
+            $(this).val(settings.npcMajorWords); // update display with clamped value
             if (settings.routerModules?.npc) {
                 settings.routerModules.npc.instruction = buildNpcInstruction(settings.npcMajorWords, settings.npcMinorWords, settings.ignoreNpcImportLimits);
             }
@@ -12249,9 +12270,11 @@ RULES:
                 globalThis._rpgRenderAgentModules();
             }
         });
-        $('#rpg_tracker_npc_minor_words').val(settings.npcMinorWords ?? 15).on('input', function () {
-            const val = parseInt(String($(this).val() || '')) || 15;
-            settings.npcMinorWords = Math.max(5, Math.min(100, val));
+        $('#rpg_tracker_npc_minor_words').val(settings.npcMinorWords ?? 15).on('change', function () {
+            const raw = parseInt(String($(this).val() || ''), 10);
+            const val = isNaN(raw) ? (settings.npcMinorWords ?? 15) : raw;
+            settings.npcMinorWords = Math.max(1, Math.min(1000, val));
+            $(this).val(settings.npcMinorWords); // update display with clamped value
             if (settings.routerModules?.npc) {
                 settings.routerModules.npc.instruction = buildNpcInstruction(settings.npcMajorWords, settings.npcMinorWords, settings.ignoreNpcImportLimits);
             }

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 import { EXAMPLES, COLOR_EXAMPLES, DEFAULT_STOCK_PROMPTS, RT_PROMPTS, BLOCK_ICONS, BLOCK_ORDER, PAGE_SIZE, NO_PAGINATE, QUESTS_NARRATOR_MODERN, QUESTS_NARRATOR_LEGACY } from './constants.js';
 import { MODULE_NAME, DEFAULT_MODULES, getSettings, getBarBackground, migrateCustomFields, saveChatState, saveProfile, deleteProfile, getEffectiveRouterCampaignPrefix, sanitizeCampaignPrefixString, buildNpcInstruction } from './state-manager.js';
 import { sendStateRequest, fetchOllamaModels, fetchOpenAIModels, testOpenAIConnection, getConnectionProfiles, getCurrentCompletionPreset, setCompletionPreset } from './llm-client.js';
-import { getDiceToolName, getDiceCommandName, getDiceCommandAliases, doDiceRoll, registerDiceFunctionTool, registerDiceSlashCommand, installInterceptor, getNarrativeBlocks, onGenerationStarted, onGenerationEnded, resetRouterTick, makeRngQueue, buildRngBlock, RNG_QUEUE_LEN } from './narrative-hooks.js';
+import { getDiceToolName, getDiceCommandName, getDiceCommandAliases, doDiceRoll, registerDiceFunctionTool, registerDiceSlashCommand, installInterceptor, getNarrativeBlocks, onGenerationStarted, onGenerationEnded, processRelationshipTags, resetRouterTick, makeRngQueue, buildRngBlock, RNG_QUEUE_LEN } from './narrative-hooks.js';
 import { deduplicateMemo, mergeMemo, computeDelta, escapeHtml, escapeRegex, highlightParens, cleanToolCallMessage, cleanMessageContent, getLastUserAction, buildLorebookContext, buildModulesInstructionText, buildModuleFormatInstruction, parseQuestsFromMemo, syncQuestsFromMemo, syncQuestsToMemo, writeQuestsToMemo, getQuestMood, extractCurrentTimeStr, stripCompletedQuestsFromMemo, parseInWorldTime } from './memo-processor.js';
 import { renderSubFieldByRule, tryRenderMarker, renderCustomBlockLine, stripMemoHtml, escapeHtmlWithColor, parseMemoBlocks, getPageSize, loadCollapsed, saveCollapsed, loadDetached, saveDetached, blockToItems, renderMemoAsCards, renderQuestLog, renderLorebookTerminal } from './renderer.js';
 import { registerLogQuestTool, checkQuestDeadlines, renderQuestsAsPlainText } from './quests.js';
@@ -9356,6 +9356,7 @@ function buildSysprompt(rawText) {
         eventSource.on(event_types.GENERATION_STARTED, onGenerationStarted);
         eventSource.on(event_types.GENERATION_ENDED, onGenerationEnded);
         eventSource.on(event_types.GENERATION_STOPPED, onGenerationEnded);
+        eventSource.on(event_types.MESSAGE_UPDATED, processRelationshipTags);
 
         // ─── Chat Link ───
         eventSource.on(event_types.CHAT_CHANGED, onChatChanged);

--- a/index.js
+++ b/index.js
@@ -4864,6 +4864,16 @@ function createPanel() {
                                     </div>
 
                                     <div style="margin-bottom:6px;display:flex;align-items:center;gap:10px;">
+                                        <label style="font-size:12px;color:rgba(255,255,255,0.7);flex:1;">Relationship Bars</label>
+                                        <label style="display:flex;align-items:center;gap:6px;cursor:pointer;">
+                                            <input type="checkbox" id="rt-npc-rel-bars" ${curS.npcRelationshipBars ? 'checked' : ''}
+                                                style="width:16px;height:16px;accent-color:#d4a940;cursor:pointer;">
+                                            <span style="font-size:11px;color:rgba(255,255,255,0.5);">${curS.npcRelationshipBars ? 'Enabled' : 'Disabled'}</span>
+                                        </label>
+                                    </div>
+                                    <div style="font-size:10px;color:rgba(255,255,255,0.35);margin-bottom:14px;">Shows Friendship/Affection tracking bars on NPC cards and popups. Also adds relationship fields to the AI instruction.</div>
+
+                                    <div style="margin-bottom:6px;display:flex;align-items:center;gap:10px;">
                                         <label style="font-size:12px;color:rgba(255,255,255,0.7);flex:1;">Character Card Converter</label>
                                         <label style="display:flex;align-items:center;gap:6px;cursor:pointer;">
                                             <input type="checkbox" id="rt-npc-card-import" ${curS.experimentalNpcImport ? 'checked' : ''}
@@ -4876,15 +4886,23 @@ function createPanel() {
 
                                 let newMajor = curS.npcMajorWords ?? 25;
                                 let newMinor = curS.npcMinorWords ?? 15;
+                                let newRel = curS.npcRelationshipBars ?? false;
                                 let newImport = curS.experimentalNpcImport ?? false;
 
                                 setTimeout(() => {
                                     const majorEl = document.getElementById('rt-npc-major-words');
                                     const minorEl = document.getElementById('rt-npc-minor-words');
+                                    const relEl = document.getElementById('rt-npc-rel-bars');
                                     const importEl = document.getElementById('rt-npc-card-import');
 
                                     if (majorEl) majorEl.addEventListener('input', () => newMajor = parseInt(majorEl.value, 10) || 25);
                                     if (minorEl) minorEl.addEventListener('input', () => newMinor = parseInt(minorEl.value, 10) || 15);
+                                    if (relEl) {
+                                        relEl.addEventListener('change', () => {
+                                            newRel = relEl.checked;
+                                            if (relEl.nextElementSibling) relEl.nextElementSibling.textContent = newRel ? 'Enabled' : 'Disabled';
+                                        });
+                                    }
                                     if (importEl) {
                                         importEl.addEventListener('change', () => {
                                             newImport = importEl.checked;
@@ -4905,10 +4923,12 @@ function createPanel() {
                                     updS.experimentalNpcImport = newImport;
                                     updS.npcMajorWords = newMajor;
                                     updS.npcMinorWords = newMinor;
+                                    updS.npcRelationshipBars = newRel;
 
                                     // Update the main settings panel inputs if present
                                     $('#rpg_tracker_npc_major_words').val(newMajor);
                                     $('#rpg_tracker_npc_minor_words').val(newMinor);
+                                    $('#rpg_tracker_npc_rel_bars').prop('checked', newRel);
                                     $('#rpg_tracker_npc_card_import').prop('checked', newImport);
 
                                     // Rebuild the NPC instruction from settings
@@ -4935,19 +4955,62 @@ function createPanel() {
                         const npcGrid = document.createElement('div');
                         npcGrid.className = 'rt-npc-card-grid';
 
+                        // Helper: parse relationship values — read from code-owned settings, not entry text
+                        const parseRelationship = (entryId) => {
+                            const s = getSettings();
+                            const rel = (s.npcRelationshipValues || {})[entryId];
+                            return {
+                                friendship: rel?.friendship ?? 0,
+                                affection:  rel?.affection  ?? 0,
+                            };
+                        };
+
+                        // Helper: render a dual-direction bar (always renders, even at 0)
+                        const renderRelBar = (value, type, entryId) => {
+                            const clamped = Math.max(-100, Math.min(100, value));
+                            const pct = Math.abs(clamped) / 2; // 50% of track = full
+                            const icon = type === 'friendship' ? '🤝' : '💗';
+                            const isPositive = clamped >= 0;
+                            const fillClass = isPositive
+                                ? `${type}-pos positive`
+                                : `${type}-neg negative`;
+                            const valClass = type === 'friendship'
+                                ? (clamped > 0 ? 'val-positive' : clamped < 0 ? 'val-negative' : 'val-zero')
+                                : (clamped > 0 ? 'val-affection-positive' : clamped < 0 ? 'val-affection-negative' : 'val-zero');
+                            // Last-delta badge from log
+                            const curS = getSettings();
+                            const log = (curS.npcRelationshipLog?.[entryId] || []).find(e => e.field === type);
+                            const badgeHtml = log
+                                ? (() => {
+                                    const badgeColor = log.source === 'manual' ? 'rgba(180,180,180,0.7)' : (log.delta > 0 ? '#4ade80' : '#ef4444');
+                                    const sign = log.delta > 0 ? '+' : '';
+                                    const label = log.source === 'manual' ? '✋' : '🤖';
+                                    return `<span style="font-size:9px;font-weight:bold;color:${badgeColor};margin-left:4px;opacity:0.85;" title="${label} last change: ${sign}${log.delta}">${sign}${log.delta}</span>`;
+                                  })()
+                                : '';
+                            return `<div class="rt-npc-bar-row">
+                                <span class="rt-npc-bar-icon">${icon}</span>
+                                <div class="rt-npc-bar-track">
+                                    <div class="rt-npc-bar-center-marker"></div>
+                                    <div class="rt-npc-bar-fill ${fillClass}" style="width:${pct}%;"></div>
+                                </div>
+                                <span class="rt-npc-bar-value ${valClass}">${clamped > 0 ? '+' : ''}${clamped}${badgeHtml}</span>
+                            </div>`;
+                        };
+
                         // Helper: get brief synopsis for the card (pulls from Appearance section or first text)
                         const getNpcDescription = (content) => {
                             if (!content) return '';
                             // Strip [CORE] and [/CORE] tags before parsing
                             const cleanContent = content.replace(/\[\/?CORE\]/gi, '');
                             // Try to extract Appearance section content first
-                            const appMatch = cleanContent.match(/Appearance:\s*(.+?)(?=\s*(?:Personality|Brief Background|Habits|Behaviors):|$)/is);
+                            const appMatch = cleanContent.match(/Appearance:\s*(.+?)(?=\s*(?:Personality|Brief Background|Habits|Behaviors|Relationship with|Friendship\/Rapport|Affection\/Interest):|$)/is);
                             if (appMatch && appMatch[1].trim()) {
                                 return appMatch[1].trim().substring(0, 140);
                             }
                             // Fallback: first meaningful text
                             const lines = cleanContent.split('\n').map(l => l.trim())
-                                .filter(l => l && !/^\[ID:/i.test(l));
+                                .filter(l => l && !/^\[ID:/i.test(l) && !/^Friendship\/Rapport:/i.test(l) && !/^Affection\/Interest:/i.test(l));
                             return lines.slice(0, 2).join(' ').substring(0, 140);
                         };
 
@@ -4973,15 +5036,15 @@ function createPanel() {
                             }
 
                             // 2. Parse core sections
-                            const sectionMarkers = /(?=(?:Appearance|Personality|Brief Background|Habits\/Behaviors|(?<!Habits\/)Behaviors)\s*:)/gi;
+                            const sectionMarkers = /(?=(?:Appearance|Personality|Brief Background|Habits\/Behaviors|(?<!Habits\/)Behaviors|Relationship with\s*\{\{user\}\}|(?<!Friendship\/|Affection\/)Relationship)\s*:)/gi;
                             const normalizedCore = coreContent.replace(sectionMarkers, '\n');
                             const coreLines = normalizedCore.split('\n');
                             let currentSection = 'General';
-                            const sectionPattern = /^(Appearance|Personality|Brief Background|Habits\/Behaviors|(?<!Habits\/)Behaviors)\s*:/i;
+                            const sectionPattern = /^(Appearance|Personality|Brief Background|Habits\/Behaviors|(?<!Habits\/)Behaviors|Relationship with\s*\{\{user\}\}|(?<!Friendship\/|Affection\/)Relationship)\s*:/i;
 
                             for (const line of coreLines) {
                                 const trimmed = line.trim();
-                                if (!trimmed || /^\[ID:/i.test(trimmed)) continue;
+                                if (!trimmed || /^\[ID:/i.test(trimmed) || /^Friendship\/Rapport:/i.test(trimmed) || /^Affection\/Interest:/i.test(trimmed)) continue;
                                 const match = trimmed.match(sectionPattern);
                                 if (match) {
                                     currentSection = match[1].replace(/\s*\{\{user\}\}/, '').replace(/\s+with$/i, '').trim();
@@ -5000,7 +5063,7 @@ function createPanel() {
                             const dynamicLines = dynamicContent.split('\n');
                             for (const line of dynamicLines) {
                                 const trimmed = line.trim();
-                                if (!trimmed || /^\[ID:/i.test(trimmed)) continue;
+                                if (!trimmed || /^\[ID:/i.test(trimmed) || /^Friendship\/Rapport:/i.test(trimmed) || /^Affection\/Interest:/i.test(trimmed)) continue;
 
                                 // Ignore lines that contain ONLY a timestamp and no other text (e.g. "[05:47 PM, Day 1]")
                                 const timestampOnlyRegex = /^\[[^\]]+\]\s*$/;
@@ -5017,11 +5080,11 @@ function createPanel() {
                         const sectionIcons = {
                             'General': '📋', 'Appearance': '👁️', 'Personality': '🧠',
                             'Brief Background': '📜', 'Habits/Behaviors': '🔄', 'Habits': '🔄',
-                            'Behaviors': '🔄',
+                            'Behaviors': '🔄', 'Relationship': '❤️',
                         };
 
                         // Helper: open NPC detail popup
-                        const openNpcDetailPopup = (item) => {
+                        const openNpcDetailPopup = (item, rel) => {
                             const ctx = SillyTavern.getContext();
                             if (!ctx.callGenericPopup) return;
                             const normLabel = item.label.replace(/\s*\(.*?\)/g, '').trim();
@@ -5041,7 +5104,7 @@ function createPanel() {
                                                          name === 'Personality' ? '#8b5cf6' :
                                                          name === 'Brief Background' ? '#3b82f6' :
                                                          name.includes('Habit') || name.includes('Behavior') ? '#10b981' :
-                                                         'var(--SmartThemeEmColor, var(--SmartThemeBodyColorTextMuted, rgba(128,128,128,0.5)))';
+                                                         name === 'Relationship' ? '#f472b6' : 'var(--SmartThemeEmColor, var(--SmartThemeBodyColorTextMuted, rgba(128,128,128,0.5)))';
                                     sectionsHtml += `<div style="margin-bottom:18px;">
                                         <div style="font-size:14px;font-weight:bold;color:${sectionColor};text-transform:uppercase;letter-spacing:1px;margin-bottom:6px;display:flex;align-items:center;gap:7px;">
                                             <span style="font-size:16px;">${icon}</span> ${escapeHtml(name)}
@@ -5069,6 +5132,34 @@ function createPanel() {
                                 sectionsHtml += `</div>`;
                             }
 
+                            // Friendship/Affection bars for popup (large version, with editable sliders)
+                            const makeBigBar = (val, label, colorPos, colorNeg, icon, type) => {
+                                const clamped = Math.max(-100, Math.min(100, val));
+                                const pct = Math.abs(clamped) / 2;
+                                const isPos = clamped >= 0;
+                                const bgColor = isPos ? colorPos : colorNeg;
+                                const valColor = clamped === 0 ? 'var(--SmartThemeEmColor, inherit)' : bgColor;
+                                return `<div style="display:grid;grid-template-columns:auto 80px 1fr 40px;align-items:center;column-gap:12px;row-gap:6px;margin-bottom:14px;">
+                                    <span style="font-size:20px;">${icon}</span>
+                                    <span style="font-size:13px;color:var(--SmartThemeBodyColor, inherit);opacity:0.65;font-weight:500;">${label}</span>
+                                    <div style="height:12px;background:var(--SmartThemeBorderColor, rgba(128,128,128,0.15));border-radius:6px;position:relative;overflow:hidden;">
+                                        <div style="position:absolute;left:50%;top:0;bottom:0;width:1px;background:var(--SmartThemeBorderColor, rgba(128,128,128,0.25));"></div>
+                                        <div id="rt-npc-detail-${type}-fill" style="position:absolute;top:0;bottom:0;border-radius:6px;background:${bgColor};${isPos ? `left:50%;width:${pct}%;` : `right:50%;width:${pct}%;`}transition:width 0.3s ease;"></div>
+                                    </div>
+                                    <span id="rt-npc-detail-${type}-text" style="font-size:15px;font-weight:bold;text-align:right;color:${valColor};font-family:monospace;">${clamped > 0 ? '+' : ''}${clamped}</span>
+                                    <div></div>
+                                    <div></div>
+                                    <input type="range" id="rt-npc-detail-${type}-slider" min="-100" max="100" value="${clamped}" step="5"
+                                        style="width:100%;margin:0;accent-color:${bgColor};height:4px;cursor:pointer;outline:none;">
+                                    <div></div>
+                                </div>`;
+                            };
+
+                            const barsHtml = `
+                                ${makeBigBar(rel.friendship, 'Friendship', '#4ade80', '#ef4444', '🤝', 'friendship')}
+                                ${makeBigBar(rel.affection, 'Affection', '#f472b6', '#a855f7', '💗', 'affection')}
+                            `;
+
                             // Full-size portrait (512px stored, display at native res)
                             const portraitEl = portraitSrc
                                 ? `<img src="${escapeHtml(portraitSrc)}" style="width:100%;height:auto;aspect-ratio:1;object-fit:cover;border-radius:12px;border:2px solid rgba(212,169,64,0.3);box-shadow:0 4px 20px rgba(0,0,0,0.4);" alt="${escapeHtml(item.label)}">`
@@ -5082,19 +5173,118 @@ function createPanel() {
                                     <div style="flex:1;min-width:220px;">
                                         <div style="font-size:24px;font-weight:bold;color:#d4a940;margin-bottom:8px;line-height:1.2;">${escapeHtml(item.label)}</div>
                                         <span style="font-size:11px;padding:3px 10px;border-radius:10px;font-weight:bold;${item.is_active ? 'background:rgba(0,255,170,0.12);color:#00ffaa;border:1px solid rgba(0,255,170,0.25);' : 'background:var(--SmartThemeBorderColor, rgba(128,128,128,0.1));color:var(--SmartThemeBodyColor, inherit);opacity:0.65;border:1px solid var(--SmartThemeBorderColor, rgba(128,128,128,0.2));'}">${item.is_active ? '● Active' : '○ Inactive'}</span>
+                                        ${s.npcRelationshipBars ? `<div style="margin-top:20px;">${barsHtml}</div>` : ''}
                                     </div>
                                 </div>
                                 <div style="border-top:2px solid rgba(212,169,64,0.15);padding-top:18px;">
                                     ${sectionsHtml || `<div style="font-size:14px;color:var(--SmartThemeBodyColor, inherit);opacity:0.5;font-style:italic;padding:16px 0;">No structured sections found. Edit the entry to add Appearance, Personality, and other sections.</div>`}
                                 </div>
+                                ${(() => {
+                                    const log = (s.npcRelationshipLog?.[item.id] || []).slice(0, 20);
+                                    if (!s.npcRelationshipBars || log.length === 0) return '';
+                                    const rows = log.map(e => {
+                                        const date = new Date(e.timestamp);
+                                        const timeStr = date.toLocaleTimeString([], {hour:'2-digit',minute:'2-digit'}) + ', ' + date.toLocaleDateString([], {month:'short',day:'numeric'});
+                                        const sign = e.delta > 0 ? '+' : '';
+                                        const deltaColor = e.delta > 0 ? '#4ade80' : '#ef4444';
+                                        const srcIcon = e.source === 'manual' ? '✋' : '🤖';
+                                        const fieldLabel = e.field === 'friendship' ? '🤝' : '💗';
+                                        return `<tr>
+                                            <td style="font-size:10px;color:var(--SmartThemeBodyColor,inherit);opacity:0.5;padding:3px 8px 3px 0;white-space:nowrap;">${timeStr}</td>
+                                            <td style="font-size:12px;padding:3px 8px;">${fieldLabel}</td>
+                                            <td style="font-size:13px;font-weight:bold;color:${deltaColor};font-family:monospace;padding:3px 8px;">${sign}${e.delta}</td>
+                                            <td style="font-size:11px;color:var(--SmartThemeBodyColor,inherit);opacity:0.45;padding:3px 0;">${srcIcon} → ${e.newValue >= 0 ? '+' : ''}${e.newValue}</td>
+                                        </tr>`;
+                                    }).join('');
+                                    return `<div style="border-top:2px solid rgba(212,169,64,0.15);padding-top:18px;margin-top:18px;">
+                                        <div style="font-size:11px;font-weight:bold;color:rgba(255,255,255,0.4);text-transform:uppercase;letter-spacing:1.5px;margin-bottom:12px;border-bottom:1px solid rgba(255,255,255,0.1);padding-bottom:4px;">📊 Relationship History</div>
+                                        <table style="width:100%;border-collapse:collapse;">${rows}</table>
+                                    </div>`;
+                                })()}
                             </div>`;
+
+
 
                             ctx.callGenericPopup(popupHtml, ctx.POPUP_TYPE?.TEXT ?? 1, '', {
                                 okButton: 'Close', cancelButton: false, wide: true, large: true,
                             });
+
+                            // Attach input change listeners to the sliders
+                            if (s.npcRelationshipBars) {
+                                setTimeout(() => {
+                                    ['friendship', 'affection'].forEach(type => {
+                                        const slider = document.getElementById(`rt-npc-detail-${type}-slider`);
+                                        if (!slider) return;
+                                        // Capture the value at drag-start for delta calculation
+                                        let valueAtDragStart = parseInt(slider.value, 10);
+                                        slider.addEventListener('mousedown', () => {
+                                            valueAtDragStart = parseInt(slider.value, 10);
+                                        });
+                                        slider.addEventListener('input', (e) => {
+                                            const newVal = parseInt(e.target.value, 10);
+                                            // 1. Update text and fill
+                                            const textEl = document.getElementById(`rt-npc-detail-${type}-text`);
+                                            const fillEl = document.getElementById(`rt-npc-detail-${type}-fill`);
+                                            if (textEl) {
+                                                textEl.textContent = (newVal > 0 ? '+' : '') + newVal;
+                                            }
+                                            if (fillEl) {
+                                                const pct = Math.abs(newVal) / 2;
+                                                fillEl.style.width = `${pct}%`;
+                                                let bgColor = '';
+                                                if (newVal >= 0) {
+                                                    fillEl.style.left = '50%';
+                                                    fillEl.style.right = 'auto';
+                                                    bgColor = type === 'friendship' ? '#4ade80' : '#f472b6';
+                                                } else {
+                                                    fillEl.style.left = 'auto';
+                                                    fillEl.style.right = '50%';
+                                                    bgColor = type === 'friendship' ? '#ef4444' : '#a855f7';
+                                                }
+                                                fillEl.style.background = bgColor;
+                                                slider.style.accentColor = bgColor;
+                                                if (textEl) {
+                                                    textEl.style.color = newVal === 0 ? 'var(--SmartThemeEmColor, inherit)' : bgColor;
+                                                }
+                                            }
+                                            // 2. Save value (log written on 'change', not on every 'input' tick)
+                                            const settings = getSettings();
+                                            if (!settings.npcRelationshipValues) settings.npcRelationshipValues = {};
+                                            if (!settings.npcRelationshipValues[item.id]) {
+                                                settings.npcRelationshipValues[item.id] = { friendship: 0, affection: 0 };
+                                            }
+                                            settings.npcRelationshipValues[item.id][type] = newVal;
+                                            saveSettings();
+                                        });
+
+                                        slider.addEventListener('change', () => {
+                                            // On drag release: compute effective delta and write a manual log entry
+                                            const settings = getSettings();
+                                            const finalVal = settings.npcRelationshipValues?.[item.id]?.[type] ?? 0;
+                                            const effectiveDelta = finalVal - valueAtDragStart;
+                                            if (effectiveDelta !== 0) {
+                                                if (!settings.npcRelationshipLog) settings.npcRelationshipLog = {};
+                                                if (!settings.npcRelationshipLog[item.id]) settings.npcRelationshipLog[item.id] = [];
+                                                settings.npcRelationshipLog[item.id].unshift({
+                                                    timestamp: Date.now(),
+                                                    field: type,
+                                                    delta: effectiveDelta,
+                                                    newValue: finalVal,
+                                                    source: 'manual',
+                                                });
+                                                if (settings.npcRelationshipLog[item.id].length > 50) settings.npcRelationshipLog[item.id].length = 50;
+                                                saveSettings();
+                                            }
+                                            valueAtDragStart = finalVal;
+                                            if (typeof refreshManifest === 'function') refreshManifest();
+                                        });
+                                    });
+                                }, 0);
+                            }
                         };
 
                         for (const item of items) {
+                            const rel = parseRelationship(item.id);
                             const desc = getNpcDescription(item.content);
                             const normLabel = item.label.replace(/\s*\(.*?\)/g, '').trim();
                             const portraitSrc = s.customPortraits?.[normLabel] || '';
@@ -5118,6 +5308,10 @@ function createPanel() {
                                     <div class="rt-npc-name">${escapeHtml(item.label)}${isDirty ? ' <span style="color:#ffa500; font-size:8px;" title="Unsaved edits">●</span>' : ''}</div>
                                     <div class="rt-npc-desc">${escapeHtml(desc)}</div>
                                     <span class="rt-npc-status-badge ${item.is_active ? 'active' : 'inactive'}">${item.is_active ? '● Active' : '○ Inactive'}</span>
+                                    ${s.npcRelationshipBars ? `<div class="rt-npc-bars">
+                                        ${renderRelBar(rel.friendship, 'friendship', item.id)}
+                                        ${renderRelBar(rel.affection, 'affection', item.id)}
+                                    </div>` : ''}
                                     <div class="rt-npc-actions">
                                         <button class="rt-npc-action-btn rt-npc-view" data-id="${item.id}" title="View NPC card"><i class="fa-solid fa-address-card"></i></button>
                                         <button class="rt-npc-action-btn rt-npc-edit" data-id="${item.id}" title="Edit entry"><i class="fa-solid fa-pen-to-square"></i></button>
@@ -5204,7 +5398,7 @@ function createPanel() {
                             const viewBtn = card.querySelector('.rt-npc-view');
                             if (viewBtn) viewBtn.addEventListener('click', (e) => {
                                 e.stopPropagation();
-                                openNpcDetailPopup(item);
+                                openNpcDetailPopup(item, rel);
                             });
 
                             const editBtn = card.querySelector('.rt-npc-edit');
@@ -5244,7 +5438,12 @@ function createPanel() {
                                     if (ok) {
                                         _dirtyEntries.delete(item.id);
                                         _openEntries.delete(item.id);
-await refreshManifest();
+                                        // Clean up code-owned relationship values for this NPC
+                                        const delSettings = getSettings();
+                                        if (delSettings.npcRelationshipValues) {
+                                            delete delSettings.npcRelationshipValues[item.id];
+                                        }
+                                        await refreshManifest();
                                         toastr['success'](`Deleted "${item.label}"`, 'NPCs');
                                     }
                                 }
@@ -5615,6 +5814,13 @@ await refreshManifest();
                 content = parts.join('\n');
             }
 
+            // Ensure relationship fields are present even in adapted content (only if bars enabled)
+            if (s.npcRelationshipBars && adaptedContent && !/Friendship\/Rapport:/i.test(content)) {
+                // Legacy: adapted content from old prompt may still include bars text — strip it
+                content = content.replace(/\s*Friendship\/Rapport:[^\n]*/gi, '')
+                                 .replace(/\s*Affection\/Interest:[^\n]*/gi, '');
+            }
+
             // Ensure the content has a [CORE] wrap around the persistent sections
             if (!/\[CORE\]/i.test(content)) {
                 const lines = content.split('\n');
@@ -5622,7 +5828,10 @@ await refreshManifest();
                 const relLines = [];
                 for (const line of lines) {
                     const trimmed = line.trim();
-                    if (trimmed || coreLines.length > 0) {
+                    if (/^Friendship\/Rapport:/i.test(trimmed) || /^Affection\/Interest:/i.test(trimmed)) {
+                        // Drop legacy text-based bar lines — values are now code-owned
+                        continue;
+                    } else if (trimmed || coreLines.length > 0) {
                         coreLines.push(line);
                     }
                 }
@@ -5706,7 +5915,11 @@ await refreshManifest();
                 s.activeRouterKeys.push(fullId);
             }
 
-
+            // Initialise code-owned relationship values for this NPC
+            if (!s.npcRelationshipValues) s.npcRelationshipValues = {};
+            if (!s.npcRelationshipValues[fullId]) {
+                s.npcRelationshipValues[fullId] = { friendship: 0, affection: 0 };
+            }
 
             // Embed avatar as portrait
             if (charCard.avatar) {
@@ -8672,6 +8885,7 @@ function buildSysprompt(rawText) {
                         }
                         $('#rpg_tracker_npc_major_words').val(sTempTracker.npcMajorWords ?? 25);
                         $('#rpg_tracker_npc_minor_words').val(sTempTracker.npcMinorWords ?? 15);
+                        $('#rpg_tracker_npc_rel_bars').prop('checked', !!sTempTracker.npcRelationshipBars);
                         $('#rpg_tracker_npc_card_import').prop('checked', !!sTempTracker.experimentalNpcImport);
                         if (typeof refreshOrderList === 'function') refreshOrderList();
 
@@ -8861,7 +9075,7 @@ function buildSysprompt(rawText) {
                                     }
                                     $('#rpg_tracker_npc_major_words').val(sTempTracker.npcMajorWords ?? 25);
                                     $('#rpg_tracker_npc_minor_words').val(sTempTracker.npcMinorWords ?? 15);
-           
+                                    $('#rpg_tracker_npc_rel_bars').prop('checked', !!sTempTracker.npcRelationshipBars);
                                     $('#rpg_tracker_npc_card_import').prop('checked', !!sTempTracker.experimentalNpcImport);
                                     if (typeof refreshOrderList === 'function') refreshOrderList();
                                     resetCount++;
@@ -11466,6 +11680,10 @@ RULES:
             if (typeof globalThis._rpgRenderAgentModules === 'function') {
                 globalThis._rpgRenderAgentModules();
             }
+        });
+        $('#rpg_tracker_npc_rel_bars').prop('checked', !!settings.npcRelationshipBars).on('change', function () {
+            settings.npcRelationshipBars = $(this).prop('checked');
+            saveSettings();
         });
         $('#rpg_tracker_npc_card_import').prop('checked', !!settings.experimentalNpcImport).on('change', function () {
             settings.experimentalNpcImport = $(this).prop('checked');

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 import { EXAMPLES, COLOR_EXAMPLES, DEFAULT_STOCK_PROMPTS, RT_PROMPTS, BLOCK_ICONS, BLOCK_ORDER, PAGE_SIZE, NO_PAGINATE, QUESTS_NARRATOR_MODERN, QUESTS_NARRATOR_LEGACY } from './constants.js';
 import { MODULE_NAME, DEFAULT_MODULES, getSettings, getBarBackground, migrateCustomFields, saveChatState, saveProfile, deleteProfile, getEffectiveRouterCampaignPrefix, sanitizeCampaignPrefixString, buildNpcInstruction } from './state-manager.js';
 import { sendStateRequest, fetchOllamaModels, fetchOpenAIModels, testOpenAIConnection, getConnectionProfiles, getCurrentCompletionPreset, setCompletionPreset } from './llm-client.js';
-import { getDiceToolName, getDiceCommandName, getDiceCommandAliases, doDiceRoll, registerDiceFunctionTool, registerDiceSlashCommand, installInterceptor, getNarrativeBlocks, onGenerationStarted, onGenerationEnded, processRelationshipTags, resetRouterTick, makeRngQueue, buildRngBlock, RNG_QUEUE_LEN } from './narrative-hooks.js';
+import { getDiceToolName, getDiceCommandName, getDiceCommandAliases, doDiceRoll, registerDiceFunctionTool, registerDiceSlashCommand, installInterceptor, getNarrativeBlocks, onGenerationStarted, onGenerationEnded, processRelationshipTags, ensureRelTagRegex, resetRouterTick, makeRngQueue, buildRngBlock, RNG_QUEUE_LEN } from './narrative-hooks.js';
 import { deduplicateMemo, mergeMemo, computeDelta, escapeHtml, escapeRegex, highlightParens, cleanToolCallMessage, cleanMessageContent, getLastUserAction, buildLorebookContext, buildModulesInstructionText, buildModuleFormatInstruction, parseQuestsFromMemo, syncQuestsFromMemo, syncQuestsToMemo, writeQuestsToMemo, getQuestMood, extractCurrentTimeStr, stripCompletedQuestsFromMemo, parseInWorldTime } from './memo-processor.js';
 import { renderSubFieldByRule, tryRenderMarker, renderCustomBlockLine, stripMemoHtml, escapeHtmlWithColor, parseMemoBlocks, getPageSize, loadCollapsed, saveCollapsed, loadDetached, saveDetached, blockToItems, renderMemoAsCards, renderQuestLog, renderLorebookTerminal } from './renderer.js';
 import { registerLogQuestTool, checkQuestDeadlines, renderQuestsAsPlainText } from './quests.js';
@@ -9357,6 +9357,9 @@ function buildSysprompt(rawText) {
         eventSource.on(event_types.GENERATION_ENDED, onGenerationEnded);
         eventSource.on(event_types.GENERATION_STOPPED, onGenerationEnded);
         eventSource.on(event_types.MESSAGE_UPDATED, processRelationshipTags);
+
+        // Auto-register the visual [REL:] tag hiding regex script
+        ensureRelTagRegex();
 
         // ─── Chat Link ───
         eventSource.on(event_types.CHAT_CHANGED, onChatChanged);

--- a/index.js
+++ b/index.js
@@ -9187,6 +9187,7 @@ function buildSysprompt(rawText) {
     let content = rawText
         .replace(/<(\w[\w_-]*)>([\s\S]*?)<\/\1>/g, (match, tag) => {
             if (mods[tag] === false) return '';
+            if (tag === 'relationship_tracking' && !s.npcRelationshipBars) return '';
             if (tag === 'rng_system' && !s.rngEnabled) {
                 const contentOnly = match.replace(/<\/?rng_system>/g, '');
                 let fallbackText = "To resolve actions, simulate a fair d20 roll internally and maintain all ROLL FORMAT rules.\n\n";
@@ -12171,6 +12172,7 @@ RULES:
         $('#rpg_tracker_npc_rel_bars').prop('checked', !!settings.npcRelationshipBars).on('change', function () {
             settings.npcRelationshipBars = $(this).prop('checked');
             saveSettings();
+            scheduleAutoApply();
         });
         // Note: experimentalNpcImport removed — NPC Creator button is always visible.
         $('#rpg_tracker_ignore_npc_limits').prop('checked', !!settings.ignoreNpcImportLimits).on('change', function () {

--- a/index.js
+++ b/index.js
@@ -5229,7 +5229,30 @@ function createPanel() {
                                         </div>
                                     </div>
                                 </div>
+                                ${(() => {
+                                    const log = (s.npcRelationshipLog?.[item.id] || []).slice(0, 20);
+                                    if (!s.npcRelationshipBars || log.length === 0) return '';
+                                    const rows = log.map(e => {
+                                        const date = new Date(e.timestamp);
+                                        const timeStr = date.toLocaleTimeString([], {hour:'2-digit',minute:'2-digit'}) + ', ' + date.toLocaleDateString([], {month:'short',day:'numeric'});
+                                        const sign = e.delta > 0 ? '+' : '';
+                                        const deltaColor = e.delta > 0 ? '#4ade80' : '#ef4444';
+                                        const srcIcon = e.source === 'manual' ? '✋' : '🤖';
+                                        const fieldLabel = e.field === 'friendship' ? '🤝' : '💗';
+                                        return `<tr>
+                                            <td style="font-size:10px;color:var(--SmartThemeBodyColor,inherit);opacity:0.5;padding:3px 8px 3px 0;white-space:nowrap;">${timeStr}</td>
+                                            <td style="font-size:12px;padding:3px 8px;">${fieldLabel}</td>
+                                            <td style="font-size:13px;font-weight:bold;color:${deltaColor};font-family:monospace;padding:3px 8px;">${sign}${e.delta}</td>
+                                            <td style="font-size:11px;color:var(--SmartThemeBodyColor,inherit);opacity:0.45;padding:3px 0;">${srcIcon} → ${e.newValue >= 0 ? '+' : ''}${e.newValue}</td>
+                                        </tr>`;
+                                    }).join('');
+                                    return `<div style="border-top:2px solid rgba(212,169,64,0.15);padding-top:18px;margin-top:18px;">
+                                        <div style="font-size:11px;font-weight:bold;color:rgba(255,255,255,0.4);text-transform:uppercase;letter-spacing:1.5px;margin-bottom:12px;border-bottom:1px solid rgba(255,255,255,0.1);padding-bottom:4px;">📊 Relationship History</div>
+                                        <table style="width:100%;border-collapse:collapse;">${rows}</table>
+                                    </div>`;
+                                })()}
                             `;
+
 
                             // Wire up in-popup edit/save/cancel
                             const viewPane = popupDom.querySelector('.rt-npc-popup-view');

--- a/index.js
+++ b/index.js
@@ -5198,26 +5198,63 @@ function createPanel() {
                             const popupDom = document.createElement('div');
                             popupDom.style.cssText = 'width:100%;box-sizing:border-box;padding:24px;text-align:left;font-family:var(--rt-font, system-ui, sans-serif);color:var(--SmartThemeBodyColor, inherit);';
 
+                            // Pre-build section HTML (avoids nested template literals confusing IDE)
+                            const sectionsInitialHtml = renderSectionsHtml(item.content)
+                                || '<div style="font-size:14px;color:var(--SmartThemeBodyColor, inherit);opacity:0.5;font-style:italic;padding:16px 0;">No structured sections found. Click Edit Text to add content.</div>';
+
+                            const barsBlockHtml = s.npcRelationshipBars
+                                ? '<div style="margin-top:20px;">' + barsHtml + '</div>'
+                                : '';
+
+                            const activeStyle = item.is_active
+                                ? 'background:rgba(0,255,170,0.12);color:#00ffaa;border:1px solid rgba(0,255,170,0.25);'
+                                : 'background:var(--SmartThemeBorderColor, rgba(128,128,128,0.1));color:var(--SmartThemeBodyColor, inherit);opacity:0.65;border:1px solid var(--SmartThemeBorderColor, rgba(128,128,128,0.2));';
+                            const activeLabel = item.is_active ? '● Active' : '○ Inactive';
+
+                            // Build relationship history log rows (plain string concatenation)
+                            let relLogHtml = '';
+                            if (s.npcRelationshipBars) {
+                                const logEntries = (s.npcRelationshipLog && s.npcRelationshipLog[item.id] || []).slice(0, 20);
+                                if (logEntries.length > 0) {
+                                    let rows = '';
+                                    for (const e of logEntries) {
+                                        const date = new Date(e.timestamp);
+                                        const timeStr = date.toLocaleTimeString([], {hour: '2-digit', minute: '2-digit'})
+                                            + ', ' + date.toLocaleDateString([], {month: 'short', day: 'numeric'});
+                                        const sign = e.delta > 0 ? '+' : '';
+                                        const deltaColor = e.delta > 0 ? '#4ade80' : '#ef4444';
+                                        const srcIcon = e.source === 'manual' ? '✋' : '🤖';
+                                        const fieldLabel = e.field === 'friendship' ? '🤝' : '💗';
+                                        rows += '<tr>'
+                                            + '<td style="font-size:10px;color:var(--SmartThemeBodyColor,inherit);opacity:0.5;padding:3px 8px 3px 0;white-space:nowrap;">' + timeStr + '</td>'
+                                            + '<td style="font-size:12px;padding:3px 8px;">' + fieldLabel + '</td>'
+                                            + '<td style="font-size:13px;font-weight:bold;color:' + deltaColor + ';font-family:monospace;padding:3px 8px;">' + sign + e.delta + '</td>'
+                                            + '<td style="font-size:11px;color:var(--SmartThemeBodyColor,inherit);opacity:0.45;padding:3px 0;">' + srcIcon + ' \u2192 ' + (e.newValue >= 0 ? '+' : '') + e.newValue + '</td>'
+                                            + '</tr>';
+                                    }
+                                    relLogHtml = '<div style="border-top:2px solid rgba(212,169,64,0.15);padding-top:18px;margin-top:18px;">'
+                                        + '<div style="font-size:11px;font-weight:bold;color:rgba(255,255,255,0.4);text-transform:uppercase;letter-spacing:1.5px;margin-bottom:12px;border-bottom:1px solid rgba(255,255,255,0.1);padding-bottom:4px;">📊 Relationship History</div>'
+                                        + '<table style="width:100%;border-collapse:collapse;">' + rows + '</table>'
+                                        + '</div>';
+                                }
+                            }
+
                             popupDom.innerHTML = `
                                 <div style="display:flex;gap:24px;margin-bottom:20px;align-items:flex-start;flex-wrap:wrap;">
-                                    <div style="flex-shrink:0;width:280px;">
-                                        ${portraitEl}
-                                    </div>
+                                    <div style="flex-shrink:0;width:280px;">${portraitEl}</div>
                                     <div style="flex:1;min-width:220px;display:flex;flex-direction:column;gap:8px;">
                                         <div style="display:flex;align-items:flex-start;justify-content:space-between;gap:12px;">
                                             <div style="font-size:24px;font-weight:bold;color:#d4a940;line-height:1.2;">${escapeHtml(item.label)}</div>
                                             <button class="rt-npc-popup-edit-btn menu_button" style="flex-shrink:0;font-size:12px;padding:4px 12px;white-space:nowrap;">✏️ Edit Text</button>
                                         </div>
-                                        <span style="font-size:11px;padding:3px 10px;border-radius:10px;font-weight:bold;align-self:flex-start;${item.is_active ? 'background:rgba(0,255,170,0.12);color:#00ffaa;border:1px solid rgba(0,255,170,0.25);' : 'background:var(--SmartThemeBorderColor, rgba(128,128,128,0.1));color:var(--SmartThemeBodyColor, inherit);opacity:0.65;border:1px solid var(--SmartThemeBorderColor, rgba(128,128,128,0.2));'}">${item.is_active ? '● Active' : '○ Inactive'}</span>
-                                        ${s.npcRelationshipBars ? `<div style="margin-top:20px;">${barsHtml}</div>` : ''}
+                                        <span style="font-size:11px;padding:3px 10px;border-radius:10px;font-weight:bold;align-self:flex-start;${activeStyle}">${activeLabel}</span>
+                                        ${barsBlockHtml}
                                     </div>
                                 </div>
                                 <div style="border-top:2px solid rgba(212,169,64,0.15);padding-top:18px;">
                                     <!-- VIEW PANE -->
                                     <div class="rt-npc-popup-view">
-                                        <div class="rt-npc-popup-sections">
-                                            ${renderSectionsHtml(item.content) || `<div style="font-size:14px;color:var(--SmartThemeBodyColor, inherit);opacity:0.5;font-style:italic;padding:16px 0;">No structured sections found. Click Edit Text to add content.</div>`}
-                                        </div>
+                                        <div class="rt-npc-popup-sections">${sectionsInitialHtml}</div>
                                     </div>
                                     <!-- EDIT PANE -->
                                     <div class="rt-npc-popup-edit" style="display:none;flex-direction:column;gap:10px;">
@@ -5229,29 +5266,9 @@ function createPanel() {
                                         </div>
                                     </div>
                                 </div>
-                                ${(() => {
-                                    const log = (s.npcRelationshipLog?.[item.id] || []).slice(0, 20);
-                                    if (!s.npcRelationshipBars || log.length === 0) return '';
-                                    const rows = log.map(e => {
-                                        const date = new Date(e.timestamp);
-                                        const timeStr = date.toLocaleTimeString([], {hour:'2-digit',minute:'2-digit'}) + ', ' + date.toLocaleDateString([], {month:'short',day:'numeric'});
-                                        const sign = e.delta > 0 ? '+' : '';
-                                        const deltaColor = e.delta > 0 ? '#4ade80' : '#ef4444';
-                                        const srcIcon = e.source === 'manual' ? '✋' : '🤖';
-                                        const fieldLabel = e.field === 'friendship' ? '🤝' : '💗';
-                                        return `<tr>
-                                            <td style="font-size:10px;color:var(--SmartThemeBodyColor,inherit);opacity:0.5;padding:3px 8px 3px 0;white-space:nowrap;">${timeStr}</td>
-                                            <td style="font-size:12px;padding:3px 8px;">${fieldLabel}</td>
-                                            <td style="font-size:13px;font-weight:bold;color:${deltaColor};font-family:monospace;padding:3px 8px;">${sign}${e.delta}</td>
-                                            <td style="font-size:11px;color:var(--SmartThemeBodyColor,inherit);opacity:0.45;padding:3px 0;">${srcIcon} → ${e.newValue >= 0 ? '+' : ''}${e.newValue}</td>
-                                        </tr>`;
-                                    }).join('');
-                                    return `<div style="border-top:2px solid rgba(212,169,64,0.15);padding-top:18px;margin-top:18px;">
-                                        <div style="font-size:11px;font-weight:bold;color:rgba(255,255,255,0.4);text-transform:uppercase;letter-spacing:1.5px;margin-bottom:12px;border-bottom:1px solid rgba(255,255,255,0.1);padding-bottom:4px;">📊 Relationship History</div>
-                                        <table style="width:100%;border-collapse:collapse;">${rows}</table>
-                                    </div>`;
-                                })()}
+                                ${relLogHtml}
                             `;
+
 
 
                             // Wire up in-popup edit/save/cancel

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
     "display_name": "Multihog D&D Framework",
-    "version": "3.16.9",
+    "version": "3.16.10",
     "author": "Disgusting Fatbody",
     "js": "index.js",
     "css": "style.css",

--- a/narrative-hooks.js
+++ b/narrative-hooks.js
@@ -841,6 +841,16 @@ export async function processRelationshipTags() {
 
     let anyChanged = false;
 
+    // Always strip the tags from the visible message FIRST to ensure they don't linger even if processing crashes
+    lastMsg.mes = rawText.replace(REL_RE, '').trimEnd();
+
+    try {
+        const lastMesEl = document.querySelector('#chat .mes:last-of-type .mes_text');
+        if (lastMesEl) lastMesEl.innerHTML = lastMesEl.innerHTML.replace(REL_RE, '');
+    } catch (_) {}
+
+    if (typeof ctx.saveChatDebounced === 'function') ctx.saveChatDebounced();
+
     for (const m of matches) {
         if (m.delta === 0) continue;
         const targetName = m.name.toLowerCase();
@@ -850,35 +860,38 @@ export async function processRelationshipTags() {
             e.comment.includes(targetName)
         );
 
-        if (!resolved) continue;
+        if (!resolved) {
+            // @ts-ignore
+            toastr.warning(`Could not find active NPC matching "${m.name}"`, 'RPG Tracker');
+            continue;
+        }
 
-        if (!settings.npcRelationshipValues) settings.npcRelationshipValues = {};
-        if (!settings.npcRelationshipValues[resolved.id]) settings.npcRelationshipValues[resolved.id] = { friendship: 0, affection: 0 };
-        
-        const prev = settings.npcRelationshipValues[resolved.id][m.field] ?? 0;
-        settings.npcRelationshipValues[resolved.id][m.field] = Math.max(-100, Math.min(100, prev + m.delta));
+        try {
+            if (!settings.npcRelationshipValues) settings.npcRelationshipValues = {};
+            if (!settings.npcRelationshipValues[resolved.id]) settings.npcRelationshipValues[resolved.id] = { friendship: 0, affection: 0 };
+            
+            const prev = settings.npcRelationshipValues[resolved.id][m.field] ?? 0;
+            settings.npcRelationshipValues[resolved.id][m.field] = Math.max(-100, Math.min(100, prev + m.delta));
 
-        if (!settings.npcRelationshipLog) settings.npcRelationshipLog = {};
-        if (!settings.npcRelationshipLog[resolved.id]) settings.npcRelationshipLog[resolved.id] = [];
-        settings.npcRelationshipLog[resolved.id].unshift({ timestamp: Date.now(), field: m.field, delta: m.delta, newValue: settings.npcRelationshipValues[resolved.id][m.field], source: 'ai' });
-        
-        const sign = m.delta > 0 ? '+' : '';
-        const icon = m.field === 'friendship' ? '🤝' : '💗';
-        const label = m.field === 'friendship' ? 'Friendship' : 'Affection';
-        // @ts-ignore
-        toastr.info(`${icon} ${m.name}: ${sign}${m.delta} ${label}`, 'Relationship', { timeOut: 3500, positionClass: 'toast-bottom-right' });
+            if (!settings.npcRelationshipLog) settings.npcRelationshipLog = {};
+            // Strict array check to prevent crashes from corrupted legacy data
+            if (!Array.isArray(settings.npcRelationshipLog[resolved.id])) settings.npcRelationshipLog[resolved.id] = [];
+            settings.npcRelationshipLog[resolved.id].unshift({ timestamp: Date.now(), field: m.field, delta: m.delta, newValue: settings.npcRelationshipValues[resolved.id][m.field], source: 'ai' });
+            
+            const sign = m.delta > 0 ? '+' : '';
+            const icon = m.field === 'friendship' ? '🤝' : '💗';
+            const label = m.field === 'friendship' ? 'Friendship' : 'Affection';
+            // @ts-ignore
+            toastr.info(`${icon} ${m.name}: ${sign}${m.delta} ${label}`, 'Relationship', { timeOut: 3500, positionClass: 'toast-bottom-right' });
 
-        anyChanged = true;
+            anyChanged = true;
+        } catch (e) {
+            console.error('[RPG Tracker] Error updating relationship for', m.name, e);
+            // @ts-ignore
+            toastr.error(`Error updating relationship for ${m.name}: ${e.message}`, 'RPG Tracker');
+        }
     }
 
-    lastMsg.mes = rawText.replace(REL_RE, '').trimEnd();
-
-    try {
-        const lastMesEl = document.querySelector('#chat .mes:last-of-type .mes_text');
-        if (lastMesEl) lastMesEl.innerHTML = lastMesEl.innerHTML.replace(REL_RE, '');
-    } catch (_) {}
-
-    if (typeof ctx.saveChatDebounced === 'function') ctx.saveChatDebounced();
     if (anyChanged) {
         ctx.saveSettingsDebounced?.();
         if (typeof globalThis._rpgRenderRouterUI === 'function') globalThis._rpgRenderRouterUI();

--- a/narrative-hooks.js
+++ b/narrative-hooks.js
@@ -396,9 +396,55 @@ async function buildNpcRelationsBlock(settings) {
     
     const header = [
         `These are the current relationship standings between the protagonist and present NPCs.`,
-        `Friendship ranges from -100 (sworn enemy) to +100 (lifelong brother/sister). Affection ranges from -100 (revulsion) to +100 (deeply in love).`,
-        `Let these values organically influence how each NPC speaks, acts, and reacts toward the protagonist. Higher values mean warmer body language, more trust, inside jokes, and willingness to help. Lower values mean hostility, suspicion, cold formality, or outright antagonism.`,
-        `When a meaningful social interaction occurs that would shift an NPC's feelings, emit a tag at the end of your response: [REL: NpcName | friendship | +/-N] or [REL: NpcName | affection | +/-N] where N is typically 1-5 for minor moments and 5-15 for major events.`,
+        `Both Friendship and Affection range from -100 to +100. These values MUST organically, subtly, and pervasively influence how every NPC speaks, acts, reacts, and behaves toward the protagonist in EVERY interaction — not just explicitly social ones.`,
+        ``,
+        `<FRIENDSHIP_TIERS>`,
+        `Friendship reflects trust, camaraderie, and mutual respect.`,
+        `-100 to -60 (HOSTILE): The NPC despises the protagonist. They refuse cooperation, speak with open contempt or threats, may actively sabotage or attack. Greetings are met with hostility ("You dare show your face here?"). Requests are flatly denied or mocked. They warn others against the protagonist.`,
+        `-59 to -30 (COLD/DISTRUSTFUL): The NPC dislikes the protagonist. Conversations are curt, dismissive, and guarded. They answer questions with the bare minimum, refuse favors, and show visible irritation. Body language is closed off — crossed arms, averted gaze, terse replies. They may comply under duress but resent it.`,
+        `-29 to -1 (WARY/UNEASY): The NPC is uncomfortable around the protagonist. Polite but distant, they keep interactions short, avoid personal topics, and maintain emotional walls. Trust must be earned — they second-guess motives and hedge their words.`,
+        `0 to +15 (NEUTRAL/ACQUAINTANCE): Standard professional courtesy. The NPC is neither warm nor cold — transactional and civil. They'll answer questions straightforwardly but won't volunteer information or go out of their way.`,
+        `+16 to +40 (FRIENDLY): The NPC genuinely likes the protagonist. Conversations flow naturally with warmth, light humor, and willingness to share. They offer unsolicited advice, remember past encounters fondly, and are inclined to help when asked. Greetings are warm ("Good to see you again!").`,
+        `+41 to +70 (CLOSE FRIEND): Deep mutual trust. The NPC shares personal stories, confides worries, and stands up for the protagonist in front of others. They offer help proactively, make sacrifices, and joke with familiar intimacy. In danger, they prioritize the protagonist's safety.`,
+        `+71 to +100 (BONDED/FAMILY): Near-unbreakable loyalty. The NPC treats the protagonist like a sibling or lifelong companion. They would risk their life without hesitation, share their deepest secrets, and defend the protagonist's honor fiercely. Conversations are effortless, filled with inside jokes and unspoken understanding.`,
+        `</FRIENDSHIP_TIERS>`,
+        ``,
+        `<AFFECTION_TIERS>`,
+        `Affection reflects romantic/physical attraction and emotional intimacy beyond friendship.`,
+        `-100 to -60 (REVULSION): The NPC finds the protagonist repulsive or deeply off-putting. Any flirtation is met with disgust, anger, or fear. They recoil from physical proximity and may feel threatened by romantic advances.`,
+        `-59 to -30 (AVERSION): The NPC is clearly uninterested and uncomfortable with any romantic subtext. Flirtation is dismissed coldly or with visible cringe. They actively steer conversations away from anything personal or intimate.`,
+        `-29 to -1 (INDIFFERENT/UNINTERESTED): No romantic spark. The NPC treats flirtation as awkward or misplaced but isn't hostile about it — more of a gentle deflection or confused look.`,
+        `0 to +15 (NEUTRAL CURIOSITY): The NPC hasn't formed romantic feelings but isn't closed off. They might blush faintly at a well-placed compliment or notice the protagonist's appearance without acting on it.`,
+        `+16 to +40 (INTERESTED): The NPC is visibly intrigued. They steal glances, respond warmly to compliments, and may initiate light flirtation themselves. Physical proximity doesn't bother them — they might lean in during conversation, touch an arm casually, or linger during goodbyes.`,
+        `+41 to +70 (ATTRACTED): Strong romantic interest. The NPC seeks out the protagonist's company, becomes flustered by bold compliments, and shows jealousy when the protagonist flirts with others. Physical tension is palpable — lingering eye contact, finding excuses to be near, playful banter with romantic undertones.`,
+        `+71 to +100 (DEEPLY IN LOVE): The NPC is emotionally devoted. They express tenderness openly, prioritize the protagonist's emotional wellbeing, and crave physical and emotional closeness. Vulnerability comes naturally, and they may express their feelings through actions (gifts, protection, grand gestures) even if they struggle to say it directly.`,
+        `</AFFECTION_TIERS>`,
+        ``,
+        `<BEHAVIORAL_RULES>`,
+        `These tiers are NOT rigid thresholds — they are a spectrum. Blend behaviors fluidly based on the exact value. An NPC at +38 friendship should act distinctly different from one at +65.`,
+        `EVERY scene should reflect these values: how NPCs greet the protagonist, how they respond to requests, how they behave in combat alongside or against them, how they react to danger, how they speak in group settings, what information they volunteer, and whether they show vulnerability.`,
+        `NPCs with high friendship but low affection treat the protagonist like a trusted comrade — warm but platonic. NPCs with high affection but low friendship might be attracted but distrustful — flirtatious yet guarded. Both values together create a unique behavioral fingerprint for each NPC.`,
+        `</BEHAVIORAL_RULES>`,
+        ``,
+        `<RELATIONSHIP_ALLOCATION>`,
+        `When a meaningful interaction occurs that would realistically shift an NPC's feelings, emit a tag at the END of your response:`,
+        `[REL: NpcName | friendship | +/-N] or [REL: NpcName | affection | +/-N]`,
+        ``,
+        `WHEN TO ALLOCATE (non-exhaustive — use judgment for ALL situations):`,
+        `• Direct compliments, insults, gifts, or threats (+/-1 to 5)`,
+        `• Sharing a meal, campfire conversation, bonding over shared interests (+1 to 3 friendship)`,
+        `• Surviving danger together, completing a quest as allies (+3 to 8 friendship)`,
+        `• Betrayal, breaking a promise, abandoning them in danger (-5 to -15 friendship)`,
+        `• Saving their life or a loved one's life (+8 to 15 friendship)`,
+        `• Flirtatious banter received well (+1 to 3 affection), received poorly (-1 to -3 affection)`,
+        `• A meaningful personal confession or vulnerable moment (+3 to 6 affection)`,
+        `• A romantic gesture — a dance, a gift with personal significance, a protective act (+4 to 8 affection)`,
+        `• Spending extended quality time together with positive interactions (+2 to 4 of either or both)`,
+        `• Disrespecting their values, culture, or loved ones (-3 to -10 friendship)`,
+        `• Ignoring them, forgetting something important to them (-1 to -3 friendship)`,
+        `These are EXAMPLES. Adapt your judgment to any situation. The magnitude should reflect the NPC's personality — a stoic warrior might give +1 where a warm innkeeper gives +3 for the same compliment.`,
+        `Typical range: 1-5 for minor moments, 5-15 for major events. Only use 15+ for life-altering moments.`,
+        `</RELATIONSHIP_ALLOCATION>`,
     ].join('\n');
 
     return `[NPC_RELATIONS]\n${header}\n\n${lines.join('\n')}\n[/NPC_RELATIONS]\n\n`;
@@ -908,8 +954,79 @@ export async function processRelationshipTags() {
 
         ctx.saveSettingsDebounced?.();
         if (typeof globalThis._rpgRenderRouterUI === 'function') globalThis._rpgRenderRouterUI();
-        if (typeof globalThis._rpgRefreshAgentManifest === 'function') globalThis._rpgRefreshAgentManifest();
+        
+        // Lightweight surgical DOM update: patch only the bar fill + value text
+        // without reloading the entire manifest (which is very slow on large installs).
+        refreshRelationshipBarsDOM(settings);
+        
         document.dispatchEvent(new CustomEvent('rt_lore_agent_updated'));
+    }
+}
+
+/**
+ * Lightweight bar-only DOM refresh. Finds every `.rt-npc-card[data-entry-id]` in the
+ * Campaign Records panel and surgically re-renders its relationship bar widths and
+ * value labels without triggering a full `getLorebookManifest()` reload.
+ * Falls back to the heavy `_rpgRefreshAgentManifest` if no cards exist yet.
+ */
+function refreshRelationshipBarsDOM(settings) {
+    const cards = document.querySelectorAll('.rt-npc-card[data-entry-id]');
+    if (!cards.length) {
+        // No cards rendered yet — fall back to full reload
+        if (typeof globalThis._rpgRefreshAgentManifest === 'function') globalThis._rpgRefreshAgentManifest();
+        return;
+    }
+
+    const relVals = settings.npcRelationshipValues || {};
+    const logData = settings.npcRelationshipLog || {};
+
+    for (const card of cards) {
+        const entryId = card.dataset.entryId;
+        if (!entryId) continue;
+        
+        const rel = relVals[entryId];
+        if (!rel) continue;
+
+        const barsContainer = card.querySelector('.rt-npc-bars');
+        if (!barsContainer) continue;
+
+        const barRows = barsContainer.querySelectorAll('.rt-npc-bar-row');
+        const types = ['friendship', 'affection'];
+
+        for (let i = 0; i < barRows.length && i < types.length; i++) {
+            const type = types[i];
+            const value = Math.max(-100, Math.min(100, rel[type] ?? 0));
+            const pct = Math.abs(value) / 2;
+            const isPositive = value >= 0;
+
+            // Update fill bar width + classes
+            const fill = barRows[i].querySelector('.rt-npc-bar-fill');
+            if (fill) {
+                fill.style.width = `${pct}%`;
+                fill.className = `rt-npc-bar-fill ${type}-${isPositive ? 'pos' : 'neg'} ${isPositive ? 'positive' : 'negative'}`;
+            }
+
+            // Update value label
+            const valSpan = barRows[i].querySelector('.rt-npc-bar-value');
+            if (valSpan) {
+                const valClass = type === 'friendship'
+                    ? (value > 0 ? 'val-positive' : value < 0 ? 'val-negative' : 'val-zero')
+                    : (value > 0 ? 'val-affection-positive' : value < 0 ? 'val-affection-negative' : 'val-zero');
+                
+                // Rebuild badge from log
+                const log = (logData[entryId] || []).find(e => e.field === type);
+                let badgeHtml = '';
+                if (log) {
+                    const badgeColor = log.source === 'manual' ? 'rgba(180,180,180,0.7)' : (log.delta > 0 ? '#4ade80' : '#ef4444');
+                    const sign = log.delta > 0 ? '+' : '';
+                    const label = log.source === 'manual' ? '✋' : '🤖';
+                    badgeHtml = `<span style="font-size:9px;font-weight:bold;color:${badgeColor};margin-left:4px;opacity:0.85;" title="${label} last change: ${sign}${log.delta}">${sign}${log.delta}</span>`;
+                }
+
+                valSpan.className = `rt-npc-bar-value ${valClass}`;
+                valSpan.innerHTML = `${value > 0 ? '+' : ''}${value}${badgeHtml}`;
+            }
+        }
     }
 }
 

--- a/narrative-hooks.js
+++ b/narrative-hooks.js
@@ -497,6 +497,13 @@ export function installInterceptor() {
         // In Path 1 (addPromptManagerInterceptor), these are built and injected by that interceptor
         // into a dedicated system message at the configured depth, protecting the prefix cache.
         if (!skipInjection) {
+        // [NPC_RELATIONS] — injected first, before RNG queue, same mechanism.
+            // Shows the narrator current relationship standings for all active NPCs.
+            if (settings.npcRelationshipBars) {
+                const relBlock = await buildNpcRelationsBlock(settings);
+                if (relBlock) injections += relBlock;
+            }
+
             if (settings.rngEnabled && !content.includes("[RNG_QUEUE v6.0_PROPER]")) {
                 const queue = makeRngQueue(RNG_QUEUE_LEN);
                 injections += buildRngBlock(queue);
@@ -801,7 +808,7 @@ export function installInterceptor() {
  */
 export async function processRelationshipTags() {
     const settings = getSettings();
-    if (!settings.npcRelationshipBars || !settings.enabled) return;
+    if (!settings.enabled) return;
 
     const ctx = SillyTavern.getContext();
     const chat = ctx.chat || [];

--- a/narrative-hooks.js
+++ b/narrative-hooks.js
@@ -352,7 +352,6 @@ function buildInjectedEntryText(id, entry, settings) {
  * @returns {Promise<string>}
  */
 async function buildNpcRelationsBlock(settings) {
-    if (!settings.npcRelationshipBars) return '';
     const relVals = settings.npcRelationshipValues || {};
     const activeKeys = settings.activeRouterKeys || [];
     if (!activeKeys.length) return '';
@@ -372,16 +371,17 @@ async function buildNpcRelationsBlock(settings) {
         const entry = bookCache[bookName]?.entries?.[uid];
         if (!entry) continue;
 
-        // NPC entries are identified by a [Major] or [Minor] tier prefix in their comment.
-        // This is framework-universal — works regardless of which lorebook the NPC lives in.
+        // Strip any leading [Tag] prefix to get the display name.
+        // We don't filter by prefix — any active entry that produces a displayName is included.
         const rawComment = entry.comment || '';
-        if (!/^\[(Major|Minor)\]/i.test(rawComment)) continue;
-
-        // Strip the tier prefix to get the display name
         const displayName = rawComment.replace(/^\[.*?\]\s*/i, '').trim();
         if (!displayName) continue;
 
-        const rel = relVals[id] || { friendship: 0, affection: 0 };
+        // Only include entries that already have relationship values tracked
+        // (avoids flooding the block with every single lorebook entry).
+        if (!relVals[id]) continue;
+
+        const rel = relVals[id];
         const f = rel.friendship ?? 0;
         const a = rel.affection ?? 0;
         const fStr = `Friendship ${f >= 0 ? '+' : ''}${f}`;
@@ -497,12 +497,9 @@ export function installInterceptor() {
         // In Path 1 (addPromptManagerInterceptor), these are built and injected by that interceptor
         // into a dedicated system message at the configured depth, protecting the prefix cache.
         if (!skipInjection) {
-        // [NPC_RELATIONS] — injected first, before RNG queue, same mechanism.
-            // Shows the narrator current relationship standings for all active NPCs.
-            if (settings.npcRelationshipBars) {
-                const relBlock = await buildNpcRelationsBlock(settings);
-                if (relBlock) injections += relBlock;
-            }
+        // [NPC_RELATIONS] — injected first, before RNG queue, same mechanism as RNG.
+            const relBlock = await buildNpcRelationsBlock(settings);
+            if (relBlock) injections += relBlock;
 
             if (settings.rngEnabled && !content.includes("[RNG_QUEUE v6.0_PROPER]")) {
                 const queue = makeRngQueue(RNG_QUEUE_LEN);
@@ -859,10 +856,11 @@ export async function processRelationshipTags() {
         const entry = bookCache[bookName]?.entries?.[uid];
         if (!entry) continue;
 
-        // NPC entries identified by [Major]/[Minor] tier prefix in comment
         const rawComment = entry.comment || '';
-        if (!/^\[(Major|Minor)\]/i.test(rawComment)) continue;
+        if (!rawComment) continue;
 
+        // Strip any leading [Tag] prefix (e.g. [Major], [Minor]) to get the display name.
+        // We do NOT filter by prefix — any active entry is a candidate.
         const displayName = rawComment.replace(/^\[.*?\]\s*/i, '').trim();
         if (!displayName) continue;
 
@@ -1098,18 +1096,6 @@ export async function onGenerationEnded() {
     // on every single generation regardless of any other system state.
     if (settings.enabled && !settings.paused) {
         await processRelationshipTags();
-
-        // Inject [NPC_RELATIONS] as a system ephemeral prompt so it reaches the narrator
-        // regardless of whether Path 1 or Path 2 context injection is active.
-        if (settings.npcRelationshipBars) {
-            const ctx = SillyTavern.getContext();
-            if (typeof ctx.setExtensionPrompt === 'function') {
-                const relBlock = await buildNpcRelationsBlock(settings);
-                // Position 1 = before main prompt, depth 0 = top of context.
-                // Empty string clears the slot when there are no active NPCs.
-                ctx.setExtensionPrompt('rpg_tracker_npc_relations', relBlock, 1, 0);
-            }
-        }
     }
 
     const isStateRunning = typeof globalThis._rpgStateModelRunning === 'function' && globalThis._rpgStateModelRunning();

--- a/narrative-hooks.js
+++ b/narrative-hooks.js
@@ -963,7 +963,7 @@ export async function processRelationshipTags(msgIndex) {
         activeEntries.push({ id, displayName, keywords, comment: (entry.comment || '').toLowerCase() });
     }
 
-    let anyChanged = false;
+
 
     for (const m of matches) {
         if (m.delta === 0) continue;

--- a/narrative-hooks.js
+++ b/narrative-hooks.js
@@ -799,63 +799,31 @@ export async function processRelationshipTags() {
 
     const ctx = SillyTavern.getContext();
     if (!ctx.chat || ctx.chat.length === 0) return;
-    const chat = ctx.chat;
-
-    // Indestructible regex: Matches [REL: A | B | C] regardless of spacing, case, or invisible chars
-    const REL_RE = /\[REL:\s*([^|]+)\|\s*([^|]+)\|\s*([^\]]+)\]/gi;
     
+    // 1. IT SEES LAST CHAT MESSAGE. ONLY
+    const lastMsg = ctx.chat[ctx.chat.length - 1];
+    if (!lastMsg || !lastMsg.mes) return;
+    if (!/\[REL:/i.test(lastMsg.mes)) return;
+
+    // 2. Extracts data using indestructible regex
+    const REL_RE = /\[REL:\s*([^|]+)\|\s*([^|]+)\|\s*([^\]]+)\]/gi;
     const matches = [];
-    let lastMsg = null;
-    let anyChanged = false;
+    let match;
+    
+    while ((match = REL_RE.exec(lastMsg.mes)) !== null) {
+        const cleanName = match[1].replace(/[\u200B\uFEFF]/g, '').trim();
+        const cleanField = match[2].replace(/[^a-z]/gi, '').toLowerCase();
+        const cleanDeltaStr = match[3].replace(/[^\d+-]/g, '');
+        const parsedDelta = parseInt(cleanDeltaStr, 10);
 
-    // Scan the last 3 messages (catches AI outputs AND user-typed manual overrides)
-    for (let i = chat.length - 1; i >= Math.max(0, chat.length - 3); i--) {
-        const msg = chat[i];
-        if (!msg || !msg.mes) continue;
-        if (!/\[REL:/i.test(msg.mes)) continue;
-
-        let msgHasMatch = false;
-        
-        const newMes = msg.mes.replace(REL_RE, (matchStr, name, field, delta, offset, fullString) => {
-            // Clean the extracted values to be completely indestructible against LLM formatting quirks
-            const cleanName = name.replace(/[\u200B\uFEFF]/g, '').trim();
-            const cleanField = field.replace(/[^a-z]/gi, '').toLowerCase();
-            const cleanDeltaStr = delta.replace(/[^\d+-]/g, '');
-            const parsedDelta = parseInt(cleanDeltaStr, 10);
-
-            if ((cleanField === 'friendship' || cleanField === 'affection') && !isNaN(parsedDelta)) {
-                matches.push({ 
-                    name: cleanName, 
-                    field: cleanField, 
-                    delta: parsedDelta 
-                });
-                msgHasMatch = true;
-                
-                // Mark as processed to prevent infinite loops on rescans
-                const processedStr = matchStr.replace(/\[REL:/i, '[PROCESSED_REL:');
-                
-                // If it is ALREADY inside an HTML comment (e.g. generated inside <!--TRACKER:), 
-                // do NOT wrap it again to prevent illegal nested comments.
-                const before = fullString.substring(0, offset);
-                if (before.lastIndexOf('<!--') > before.lastIndexOf('-->')) {
-                    return processedStr; 
-                }
-
-                // If it's visible text, wrap it in standard HTML comments so ST hides it natively
-                return `<!-- ${processedStr} -->`;
-            }
-
-            return matchStr; // If it was malformed beyond repair, don't touch it
-        });
-
-        if (msgHasMatch) {
-            msg.mes = newMes.trimEnd();
-            lastMsg = msg;
+        if ((cleanField === 'friendship' || cleanField === 'affection') && !isNaN(parsedDelta)) {
+            matches.push({ name: cleanName, field: cleanField, delta: parsedDelta });
         }
     }
 
     if (matches.length === 0) return;
 
+    // Load active entries to resolve NPC IDs
     const activeKeys = [...(settings.activeRouterKeys || []), ...(settings.activeWorldKeys || [])];
     const bookCache = {};
     const activeEntries = [];
@@ -874,22 +842,7 @@ export async function processRelationshipTags() {
         activeEntries.push({ id, displayName, keywords, comment: (entry.comment || '').toLowerCase() });
     }
 
-    try {
-        // Force the DOM to hide it immediately if it's in the last message
-        const lastMesEls = document.querySelectorAll('#chat .mes .mes_text');
-        for (const el of lastMesEls) {
-            if (el.innerHTML.includes('[REL:')) {
-                el.innerHTML = el.innerHTML.replace(REL_RE, (matchStr, name, field, delta, offset, fullString) => {
-                    const processedStr = matchStr.replace(/\[REL:/i, '[PROCESSED_REL:');
-                    const before = fullString.substring(0, offset);
-                    if (before.lastIndexOf('<!--') > before.lastIndexOf('-->')) return processedStr;
-                    return `<!-- ${processedStr} -->`;
-                });
-            }
-        }
-    } catch (_) {}
-
-    if (lastMsg && typeof ctx.saveChatDebounced === 'function') ctx.saveChatDebounced();
+    let anyChanged = false;
 
     for (const m of matches) {
         if (m.delta === 0) continue;

--- a/narrative-hooks.js
+++ b/narrative-hooks.js
@@ -801,22 +801,31 @@ export async function processRelationshipTags() {
     if (!ctx.chat || ctx.chat.length === 0) return;
     const chat = ctx.chat;
 
-    // Find the last assistant message
-    let lastMsg = null;
-    for (let i = chat.length - 1; i >= 0; i--) {
-        if (!chat[i].is_user && !chat[i].is_system) { lastMsg = chat[i]; break; }
-    }
-    if (!lastMsg) return;
-
-    const rawText = lastMsg.mes || '';
-    if (!rawText.includes('[REL:')) return;
-
-    // Regex matches [REL: Name | field | delta]
-    const REL_RE = /\[REL:\s*([^|\]]+)\|\s*(friendship|affection)\s*\|\s*([+-]?\d+)\s*\]/gi;
+    // Regex matches [REL: Name | field | delta] but IGNORES ones already wrapped in <!-- -->
+    const REL_RE = /(?<!<!--\s*)\[REL:\s*([^|\]]+)\|\s*(friendship|affection)\s*\|\s*([+-]?\s*\d+)\s*\]/gi;
+    
     const matches = [];
-    let match;
-    while ((match = REL_RE.exec(rawText)) !== null) {
-        matches.push({ name: match[1].trim(), field: match[2].toLowerCase(), delta: parseInt(match[3], 10) });
+    let lastMsg = null;
+    let anyChanged = false;
+
+    // Scan the last 3 messages (catches AI outputs AND user-typed manual overrides)
+    for (let i = chat.length - 1; i >= Math.max(0, chat.length - 3); i--) {
+        const msg = chat[i];
+        if (!msg || !msg.mes) continue;
+        if (!msg.mes.includes('[REL:')) continue;
+
+        let match;
+        let msgHasMatch = false;
+        while ((match = REL_RE.exec(msg.mes)) !== null) {
+            matches.push({ name: match[1].trim(), field: match[2].toLowerCase(), delta: parseInt(match[3].replace(/\s+/g, ''), 10) });
+            msgHasMatch = true;
+        }
+
+        if (msgHasMatch) {
+            // Always WRAP the tags in HTML comments so they are hidden from the user but remain in the context
+            msg.mes = msg.mes.replace(REL_RE, (m) => `<!-- ${m} -->`).trimEnd();
+            lastMsg = msg; // Track that we modified at least one message
+        }
     }
 
     if (matches.length === 0) return;
@@ -839,17 +848,17 @@ export async function processRelationshipTags() {
         activeEntries.push({ id, displayName, keywords, comment: (entry.comment || '').toLowerCase() });
     }
 
-    let anyChanged = false;
-
-    // Always strip the tags from the visible message FIRST to ensure they don't linger even if processing crashes
-    lastMsg.mes = rawText.replace(REL_RE, '').trimEnd();
-
     try {
-        const lastMesEl = document.querySelector('#chat .mes:last-of-type .mes_text');
-        if (lastMesEl) lastMesEl.innerHTML = lastMesEl.innerHTML.replace(REL_RE, '');
+        // Also force the DOM to hide it immediately if it's in the last message
+        const lastMesEls = document.querySelectorAll('#chat .mes .mes_text');
+        for (const el of lastMesEls) {
+            if (el.innerHTML.includes('[REL:')) {
+                el.innerHTML = el.innerHTML.replace(REL_RE, (m) => `<!-- ${m} -->`);
+            }
+        }
     } catch (_) {}
 
-    if (typeof ctx.saveChatDebounced === 'function') ctx.saveChatDebounced();
+    if (lastMsg && typeof ctx.saveChatDebounced === 'function') ctx.saveChatDebounced();
 
     for (const m of matches) {
         if (m.delta === 0) continue;

--- a/narrative-hooks.js
+++ b/narrative-hooks.js
@@ -336,7 +336,7 @@ function buildInjectedEntryText(id, entry, settings) {
         // Inject relationship values immediately below the entity header
         content = `Relationship with {{user}}: Friendship: ${friendship}/100, Affection: ${affection}/100\n${content}`;
     }
-    const label = entry.key?.[0] || entry.comment || id.split('::')[1];
+const label = entry.key?.[0] || entry.comment || id.split('::')[1];
     return `### [${label}]\n${content}\n\n`;
 }
 
@@ -559,7 +559,7 @@ export function installInterceptor() {
                 const triggered = await scanAssistantOutputForKeywords(content, { sweepEnabled: false }).catch(() => []);
                 console.log('activeRouterKeys AFTER scan:', JSON.stringify(settings.activeRouterKeys || []));
                 console.log('newly triggered this scan:', triggered);
-                console.log(`scan finished @ ${performance.now().toFixed(1)}ms`);
+                console.log(`scan finished @ ${performance.now().toFixed(1) }ms`);
 
                 // Trigger UI refresh so the Agent Panel updates immediately with yellow pills
                 if (triggered.length > 0 && typeof globalThis._rpgRenderRouterUI === 'function') {
@@ -790,22 +790,8 @@ export function installInterceptor() {
     };
 }
 
-
-// ── Relationship tag processor ─────────────────────────────────────────────────
-
 /**
  * Processes [REL: Name | field | delta] tags emitted by the narrator AI.
- *
- * For each tag found in the last assistant message:
- *  1. Resolves the NPC first-name to an active lorebook entry ID
- *  2. Applies the delta to settings.npcRelationshipValues (clamped ±100)
- *  3. Appends to settings.npcRelationshipLog with source:'ai'
- *  4. Writes the updated values back to the lorebook entry (the persistent database)
- *  5. Shows a toast notification
- * Then strips all [REL: ...] tags from the visible message and refreshes the UI.
- *
- * Called as Step 0 of onGenerationEnded so bars update on EVERY turn, even when
- * the Lorebook Agent is throttled.
  */
 export async function processRelationshipTags() {
     const settings = getSettings();
@@ -823,24 +809,22 @@ export async function processRelationshipTags() {
     if (!lastMsg) return;
 
     const rawText = lastMsg.mes || '';
-    if (!rawText.includes('[REL:')) return; // fast exit
+    if (!rawText.includes('[REL:')) return;
 
-    // Strict regex exactly matching what the AI is told to output
+    // Regex matches [REL: Name | field | delta]
     const REL_RE = /\[REL:\s*([^|\]]+)\|\s*(friendship|affection)\s*\|\s*([+-]?\d+)\s*\]/gi;
-    let matches = [];
+    const matches = [];
     let match;
     while ((match = REL_RE.exec(rawText)) !== null) {
         matches.push({ name: match[1].trim(), field: match[2].toLowerCase(), delta: parseInt(match[3], 10) });
     }
 
-    if (!matches.length) return;
+    if (matches.length === 0) return;
 
-    // Combine all active keys from the state manager's tracking
     const activeKeys = [...(settings.activeRouterKeys || []), ...(settings.activeWorldKeys || [])];
     const bookCache = {};
     const activeEntries = [];
 
-    // Cache the active entries to search against
     for (const id of activeKeys) {
         const [bookName, uid] = id.split('::');
         if (!bookName || !uid) continue;
@@ -850,103 +834,47 @@ export async function processRelationshipTags() {
         const entry = bookCache[bookName]?.entries?.[uid];
         if (!entry) continue;
 
-        // Clean the display name from the comment field
-        const rawComment = entry.comment || '';
-        const displayName = rawComment.replace(/^\[.*?\]\s*/i, '').trim();
-        
-        // Extract all keywords as an array of lowercase strings
+        const displayName = (entry.comment || '').replace(/^\[.*?\]\s*/i, '').trim();
         const keywords = Array.isArray(entry.key) ? entry.key.map(k => k.toLowerCase().trim()) : [];
-
-        activeEntries.push({ id, displayName, keywords, comment: rawComment.toLowerCase() });
+        activeEntries.push({ id, displayName, keywords, comment: (entry.comment || '').toLowerCase() });
     }
 
     let anyChanged = false;
 
     for (const m of matches) {
         if (m.delta === 0) continue;
-        
         const targetName = m.name.toLowerCase();
-        let resolvedId = null;
+        const resolved = activeEntries.find(e => 
+            e.displayName.toLowerCase() === targetName || 
+            e.keywords.some(k => k === targetName) || 
+            e.comment.includes(targetName)
+        );
 
-        // PASS 1: Exact Display Name match
-        const exactMatch = activeEntries.find(e => e.displayName.toLowerCase() === targetName);
-        if (exactMatch) {
-            resolvedId = exactMatch.id;
-        } else {
-            // PASS 2: Search within keywords
-            // The AI might output "Harys", and the keyword might be "Ser Harys Swyft"
-            const keywordMatch = activeEntries.find(e => 
-                e.keywords.some(k => k.includes(targetName) || targetName.includes(k))
-            );
-            if (keywordMatch) {
-                resolvedId = keywordMatch.id;
-            } else {
-                // PASS 3: Broad substring match against the raw comment
-                const commentMatch = activeEntries.find(e => e.comment.includes(targetName));
-                if (commentMatch) resolvedId = commentMatch.id;
-            }
-        }
+        if (!resolved) continue;
 
-        if (!resolvedId) {
-            if (settings.debugMode) console.log(`[RPG Tracker] REL: Could not map "${m.name}" to any active entry.`);
-            // @ts-ignore
-            toastr.warning(`Could not map AI relationship tag for "${m.name}" to an active Lorebook entry.`, 'RPG Tracker');
-            continue;
-        }
-
-        // Apply delta directly to the central settings state
         if (!settings.npcRelationshipValues) settings.npcRelationshipValues = {};
-        if (!settings.npcRelationshipValues[resolvedId]) {
-            settings.npcRelationshipValues[resolvedId] = { friendship: 0, affection: 0 };
-        }
-        const prev = settings.npcRelationshipValues[resolvedId][m.field] ?? 0;
-        const newVal = Math.max(-100, Math.min(100, prev + m.delta));
-        settings.npcRelationshipValues[resolvedId][m.field] = newVal;
+        if (!settings.npcRelationshipValues[resolved.id]) settings.npcRelationshipValues[resolved.id] = { friendship: 0, affection: 0 };
+        
+        const prev = settings.npcRelationshipValues[resolved.id][m.field] ?? 0;
+        settings.npcRelationshipValues[resolved.id][m.field] = Math.max(-100, Math.min(100, prev + m.delta));
 
-        // Log entry for the UI history
         if (!settings.npcRelationshipLog) settings.npcRelationshipLog = {};
-        if (!settings.npcRelationshipLog[resolvedId]) settings.npcRelationshipLog[resolvedId] = [];
-        settings.npcRelationshipLog[resolvedId].unshift({
-            timestamp: Date.now(),
-            field: m.field,
-            delta: m.delta,
-            newValue: newVal,
-            source: 'ai',
-        });
-        if (settings.npcRelationshipLog[resolvedId].length > 50) {
-            settings.npcRelationshipLog[resolvedId].length = 50;
-        }
-
-        // Toast success
-        const sign = m.delta > 0 ? '+' : '';
-        const icon = m.field === 'friendship' ? '🤝' : '💗';
-        const label = m.field === 'friendship' ? 'Friendship' : 'Affection';
-        // @ts-ignore
-        toastr.info(`${icon} ${m.name}: ${sign}${m.delta} ${label}`, 'Relationship', { timeOut: 3500, positionClass: 'toast-bottom-right' });
-
+        if (!settings.npcRelationshipLog[resolved.id]) settings.npcRelationshipLog[resolved.id] = [];
+        settings.npcRelationshipLog[resolved.id].unshift({ timestamp: Date.now(), field: m.field, delta: m.delta, newValue: settings.npcRelationshipValues[resolved.id][m.field], source: 'ai' });
+        
         anyChanged = true;
     }
 
-    // Always strip the tags from the visible message, even if no matches resolved.
-    // We do not want machine tags visible to the user or lingering in the chat context.
-    lastMsg.mes = rawText.replace(/\[REL:\s*[^|\]]+\|\s*(?:friendship|affection)\s*\|\s*[+-]?\d+\s*\]/gi, '').trimEnd();
+    lastMsg.mes = rawText.replace(REL_RE, '').trimEnd();
 
-    // Update the DOM to hide it immediately
     try {
         const lastMesEl = document.querySelector('#chat .mes:last-of-type .mes_text');
-        if (lastMesEl) {
-            const html = lastMesEl.innerHTML;
-            const cleaned = html.replace(/\[REL:\s*[^|<]+\|\s*(?:friendship|affection)\s*\|\s*[+-]?\d+\s*\]/gi, '');
-            if (cleaned !== html) lastMesEl.innerHTML = cleaned;
-        }
+        if (lastMesEl) lastMesEl.innerHTML = lastMesEl.innerHTML.replace(REL_RE, '');
     } catch (_) {}
 
-    // Persist modifications to chat history
     if (typeof ctx.saveChatDebounced === 'function') ctx.saveChatDebounced();
-    
     if (anyChanged) {
         ctx.saveSettingsDebounced?.();
-        // Force the Campaign Records UI to rerender and show the new relationship bars
         if (typeof globalThis._rpgRenderRouterUI === 'function') globalThis._rpgRenderRouterUI();
         document.dispatchEvent(new CustomEvent('rt_lore_agent_updated'));
     }

--- a/narrative-hooks.js
+++ b/narrative-hooks.js
@@ -836,8 +836,8 @@ export async function processRelationshipTags() {
                     delta: parsedDelta 
                 });
                 msgHasMatch = true;
-                // Wrap in <!--TRACKER: to integrate with the user's regex preset
-                return `<!--TRACKER: ${matchStr}-->`;
+                // Wrap in standard HTML comments so it is natively hidden by the Markdown parser
+                return `<!-- ${matchStr} -->`;
             }
 
             return matchStr; // If it was malformed beyond repair, don't touch it

--- a/narrative-hooks.js
+++ b/narrative-hooks.js
@@ -885,8 +885,13 @@ export async function processRelationshipTags() {
     }
 
     if (anyChanged) {
+        // Prevent infinite allocations on manual edits/swipes by renaming the processed tag
+        lastMsg.mes = lastMsg.mes.replace(/\[REL:/gi, '[PROCESSED_REL:');
+        if (typeof ctx.saveChatDebounced === 'function') ctx.saveChatDebounced();
+
         ctx.saveSettingsDebounced?.();
         if (typeof globalThis._rpgRenderRouterUI === 'function') globalThis._rpgRenderRouterUI();
+        if (typeof globalThis._rpgRefreshNpcManifest === 'function') globalThis._rpgRefreshNpcManifest();
         document.dispatchEvent(new CustomEvent('rt_lore_agent_updated'));
     }
 }

--- a/narrative-hooks.js
+++ b/narrative-hooks.js
@@ -497,13 +497,6 @@ export function installInterceptor() {
         // In Path 1 (addPromptManagerInterceptor), these are built and injected by that interceptor
         // into a dedicated system message at the configured depth, protecting the prefix cache.
         if (!skipInjection) {
-            // [NPC_RELATIONS] block — prepended first so it has maximum salience in context.
-            // Shows the narrator current relationship standings for all active NPCs.
-            if (settings.npcRelationshipBars) {
-                const relBlock = await buildNpcRelationsBlock(settings);
-                if (relBlock) injections += relBlock;
-            }
-
             if (settings.rngEnabled && !content.includes("[RNG_QUEUE v6.0_PROPER]")) {
                 const queue = makeRngQueue(RNG_QUEUE_LEN);
                 injections += buildRngBlock(queue);
@@ -1092,6 +1085,26 @@ export function resetRouterTick(clearKeywordPool = false) {
  */
 export async function onGenerationEnded() {
     const settings = getSettings();
+
+    // Step 0: Relationship tag processing — runs FIRST, before all other guards
+    // (isStateRunning, combinedNarrative, throttles). This guarantees bars update
+    // on every single generation regardless of any other system state.
+    if (settings.enabled && !settings.paused) {
+        await processRelationshipTags();
+
+        // Inject [NPC_RELATIONS] as a system ephemeral prompt so it reaches the narrator
+        // regardless of whether Path 1 or Path 2 context injection is active.
+        if (settings.npcRelationshipBars) {
+            const ctx = SillyTavern.getContext();
+            if (typeof ctx.setExtensionPrompt === 'function') {
+                const relBlock = await buildNpcRelationsBlock(settings);
+                // Position 1 = before main prompt, depth 0 = top of context.
+                // Empty string clears the slot when there are no active NPCs.
+                ctx.setExtensionPrompt('rpg_tracker_npc_relations', relBlock, 1, 0);
+            }
+        }
+    }
+
     const isStateRunning = typeof globalThis._rpgStateModelRunning === 'function' && globalThis._rpgStateModelRunning();
     if (!settings.enabled || settings.paused || isStateRunning) return;
 
@@ -1113,10 +1126,6 @@ export async function onGenerationEnded() {
     const { chat } = SillyTavern.getContext();
     const combinedNarrative = getNarrativeBlocks(chat, -1, !!settings.routerIncludeHidden);
     if (!combinedNarrative) return;
-
-    // Step 0: Process relationship tags — runs on EVERY generation, before all throttles,
-    // so bars update in real time even when the Lorebook Agent is idle.
-    await processRelationshipTags();
 
     if (settings.debugMode) console.log("[RPG Tracker] Assistant generation ended. Running keyword scanner...");
 

--- a/narrative-hooks.js
+++ b/narrative-hooks.js
@@ -825,14 +825,30 @@ export function installInterceptor() {
 /**
  * Processes [REL: Name | field | delta] tags emitted by the narrator AI.
  */
-export async function processRelationshipTags() {
+export async function processRelationshipTags(msgIndex) {
     const settings = getSettings();
 
     const ctx = SillyTavern.getContext();
     if (!ctx.chat || ctx.chat.length === 0) return;
     
-    // 1. IT SEES LAST CHAT MESSAGE. ONLY
-    const lastMsg = ctx.chat[ctx.chat.length - 1];
+    // Resolve the target message.
+    // If called from MESSAGE_UPDATED, msgIndex is the exact message to check.
+    // If called from GENERATION_ENDED (no index), scan backwards for the last
+    // AI message that actually contains a [REL:] tag — avoids the race where
+    // chat.length-1 is still the user's turn when the event fires.
+    let lastMsg;
+    if (typeof msgIndex === 'number' && msgIndex >= 0 && msgIndex < ctx.chat.length) {
+        lastMsg = ctx.chat[msgIndex];
+    } else {
+        // Scan from end backwards, skipping user messages, until we find one with [REL:]
+        for (let i = ctx.chat.length - 1; i >= Math.max(0, ctx.chat.length - 5); i--) {
+            const msg = ctx.chat[i];
+            if (msg && !msg.is_user && msg.mes && /\[REL:/i.test(msg.mes)) {
+                lastMsg = msg;
+                break;
+            }
+        }
+    }
     if (!lastMsg || !lastMsg.mes) return;
     if (!/\[REL:/i.test(lastMsg.mes)) return;
 
@@ -1141,9 +1157,10 @@ export function resetRouterTick(clearKeywordPool = false) {
 export async function onGenerationEnded() {
     const settings = getSettings();
 
-    // Step 0: Relationship tag processing - runs FIRST, unconditionally.
-    // This guarantees bars update on every single generation even if the main lore agent is paused.
-    await processRelationshipTags();
+    // Step 0: Relationship tag processing — deferred one tick so ST has time
+    // to fully commit the AI message to ctx.chat before we try to read it.
+    // Without this, ctx.chat[length-1] can still be the user's message.
+    setTimeout(() => processRelationshipTags(), 0);
 
     const isStateRunning = typeof globalThis._rpgStateModelRunning === 'function' && globalThis._rpgStateModelRunning();
     if (!settings.enabled || settings.paused || isStateRunning) return;

--- a/narrative-hooks.js
+++ b/narrative-hooks.js
@@ -863,13 +863,26 @@ export async function processRelationshipTags(msgIndex) {
     
     // Ensure the message has an extra metadata dictionary for tracking processed tags
     lastMsg.extra = lastMsg.extra || {};
-    lastMsg.extra.rpgProcessedTags = lastMsg.extra.rpgProcessedTags || [];
+    // Use swipe_id to prevent previous swipes from falsely deduplicating the current swipe
+    const swipeId = lastMsg.swipe_id ?? 0;
+    
+    // Convert old array format to object-keyed-by-swipe format if needed
+    if (Array.isArray(lastMsg.extra.rpgProcessedTags)) {
+        lastMsg.extra.rpgProcessedTags = { [swipeId]: lastMsg.extra.rpgProcessedTags };
+    } else if (!lastMsg.extra.rpgProcessedTags) {
+        lastMsg.extra.rpgProcessedTags = {};
+    }
+    
+    lastMsg.extra.rpgProcessedTags[swipeId] = lastMsg.extra.rpgProcessedTags[swipeId] || [];
 
     while ((match = REL_RE.exec(lastMsg.mes)) !== null) {
         const matchStr = match[0];
         
-        // Skip if this exact tag string has already been processed for this message
-        if (lastMsg.extra.rpgProcessedTags.includes(matchStr)) continue;
+        // Skip if this exact tag string has already been processed for THIS specific swipe
+        if (lastMsg.extra.rpgProcessedTags[swipeId].includes(matchStr)) {
+            console.log('[RPG Tracker] Skipping tag, already processed for this swipe:', matchStr);
+            continue;
+        }
 
         const cleanName = match[1].replace(/[\u200B\uFEFF]/g, '').trim();
         const cleanField = match[2].replace(/[^a-z]/gi, '').toLowerCase();
@@ -942,9 +955,10 @@ export async function processRelationshipTags(msgIndex) {
             const label = m.field === 'friendship' ? 'Friendship' : 'Affection';
             // @ts-ignore
             toastr.info(`${icon} ${m.name}: ${sign}${m.delta} ${label}`, 'Relationship', { timeOut: 3500, positionClass: 'toast-bottom-right' });
+            console.log(`[RPG Tracker] Applied relationship delta: ${m.name} | ${m.field} | ${m.delta}`);
 
-            // Mark this specific tag string as processed in the message metadata
-            lastMsg.extra.rpgProcessedTags.push(m.rawStr);
+            // Mark this specific tag string as processed in the message metadata for THIS swipe
+            lastMsg.extra.rpgProcessedTags[swipeId].push(m.rawStr);
             anyChanged = true;
         } catch (e) {
             console.error('[RPG Tracker] Error updating relationship for', m.name, e);

--- a/narrative-hooks.js
+++ b/narrative-hooks.js
@@ -365,9 +365,6 @@ async function buildNpcRelationsBlock(settings) {
     for (const id of activeKeys) {
         const [bookName, uid] = id.split('::');
         if (!bookName || !uid) continue;
-        // Only NPC books
-        const bl = bookName.toLowerCase();
-        if (!bl.endsWith('_npcs') && !bl.endsWith('_npc') && bl !== 'npcs' && bl !== 'npc') continue;
 
         if (!bookCache[bookName]) {
             try { bookCache[bookName] = await ctx.loadWorldInfo(bookName); } catch (_) { bookCache[bookName] = null; }
@@ -375,8 +372,13 @@ async function buildNpcRelationsBlock(settings) {
         const entry = bookCache[bookName]?.entries?.[uid];
         if (!entry) continue;
 
-        // Strip [Major] / [Minor] prefix from comment to get the display name
-        const displayName = (entry.comment || '').replace(/^\[.*?\]\s*/i, '').trim();
+        // NPC entries are identified by a [Major] or [Minor] tier prefix in their comment.
+        // This is framework-universal — works regardless of which lorebook the NPC lives in.
+        const rawComment = entry.comment || '';
+        if (!/^\[(Major|Minor)\]/i.test(rawComment)) continue;
+
+        // Strip the tier prefix to get the display name
+        const displayName = rawComment.replace(/^\[.*?\]\s*/i, '').trim();
         if (!displayName) continue;
 
         const rel = relVals[id] || { friendship: 0, affection: 0 };
@@ -830,19 +832,26 @@ export async function processRelationshipTags() {
     }
     if (!matches.length) return;
 
-    // ── Build first-name lookup from active NPC lorebook entries ──────────────
+    // ── Build multi-key name lookup from active NPC lorebook entries ──────────
+    // NPC entries are identified by [Major]/[Minor] comment prefix (framework standard).
+    // The map stores MULTIPLE keys per NPC: full name, each significant word (length > 2).
+    // This resolves titled NPCs like "Ser Harys Swyft" whether the AI writes the full
+    // name, a partial name, or just a given name.
     const activeKeys = settings.activeRouterKeys || [];
     /** @type {Record<string, any>} */
     const bookCache = {};
-    // firstNameMap: lowerCaseFirstName -> [{ id, displayName }]
     /** @type {Record<string, Array<{id:string, displayName:string}>>} */
-    const firstNameMap = {};
+    const nameMap = {};
+
+    const _addToMap = (key, entry) => {
+        if (!key || key.length < 2) return;
+        if (!nameMap[key]) nameMap[key] = [];
+        nameMap[key].push(entry);
+    };
 
     for (const id of activeKeys) {
         const [bookName, uid] = id.split('::');
         if (!bookName || !uid) continue;
-        const bl = bookName.toLowerCase();
-        if (!bl.endsWith('_npcs') && !bl.endsWith('_npc') && bl !== 'npcs' && bl !== 'npc') continue;
 
         if (!bookCache[bookName]) {
             try { bookCache[bookName] = await ctx.loadWorldInfo(bookName); } catch (_) { bookCache[bookName] = null; }
@@ -850,12 +859,22 @@ export async function processRelationshipTags() {
         const entry = bookCache[bookName]?.entries?.[uid];
         if (!entry) continue;
 
-        const displayName = (entry.comment || '').replace(/^\[.*?\]\s*/i, '').trim();
+        // NPC entries identified by [Major]/[Minor] tier prefix in comment
+        const rawComment = entry.comment || '';
+        if (!/^\[(Major|Minor)\]/i.test(rawComment)) continue;
+
+        const displayName = rawComment.replace(/^\[.*?\]\s*/i, '').trim();
         if (!displayName) continue;
 
-        const firstName = displayName.split(/\s+/)[0].toLowerCase();
-        if (!firstNameMap[firstName]) firstNameMap[firstName] = [];
-        firstNameMap[firstName].push({ id, displayName });
+        const rec = { id, displayName };
+        const nameLc = displayName.toLowerCase();
+
+        // Key 1: full display name ("ser harys swyft")
+        _addToMap(nameLc, rec);
+        // Key 2: each significant word (length > 2), so "harys", "swyft", "ser" all resolve
+        for (const word of nameLc.split(/\s+/)) {
+            if (word.length > 2) _addToMap(word, rec);
+        }
     }
 
     // ── Process each match ────────────────────────────────────────────────────
@@ -865,16 +884,33 @@ export async function processRelationshipTags() {
         if (match.delta === 0) continue;
 
         // Resolve NPC name → entry ID
+        // Strategy: exact full-name match first, then word-by-word fallback.
         const nameLower = match.name.toLowerCase();
-        const candidates = firstNameMap[nameLower] || [];
+
+        // Pass 1: exact match on the full tag name (handles "Ser Harys Swyft", "Elena", etc.)
+        let candidates = nameMap[nameLower] || [];
+
+        // Pass 2: word-by-word fallback — union of all candidates whose display name
+        // shares at least one significant word with the tag name.
+        if (!candidates.length) {
+            const tagWords = nameLower.split(/\s+/).filter(w => w.length > 2);
+            const seen = new Map();
+            for (const word of tagWords) {
+                for (const c of (nameMap[word] || [])) {
+                    if (!seen.has(c.id)) seen.set(c.id, c);
+                }
+            }
+            candidates = [...seen.values()];
+        }
+
         let resolvedId = null;
 
         if (candidates.length === 1) {
             resolvedId = candidates[0].id;
         } else if (candidates.length > 1) {
-            // Ambiguous first name — try exact full-name match
-            const full = candidates.find(c => c.displayName.toLowerCase() === nameLower);
-            if (full) resolvedId = full.id;
+            // Ambiguous — prefer the candidate whose full display name most closely matches
+            const exact = candidates.find(c => c.displayName.toLowerCase() === nameLower);
+            if (exact) resolvedId = exact.id;
             else {
                 if (settings.debugMode) console.warn(`[RPG Tracker] REL: ambiguous NPC name "${match.name}" (${candidates.length} matches) — skipping.`);
                 continue;

--- a/narrative-hooks.js
+++ b/narrative-hooks.js
@@ -14,7 +14,7 @@
 
 import { getSettings } from './state-manager.js';
 import { parseQuestsFromMemo, extractCurrentTimeStr, cleanMessageContent } from './memo-processor.js';
-import { runRouterPass, saveSceneToLorebook, scanAssistantOutputForKeywords, parseInWorldMinutes, runWorldProgressionPass } from './router.js';
+import { runRouterPass, saveSceneToLorebook, scanAssistantOutputForKeywords, parseInWorldMinutes, runWorldProgressionPass, updateLorebookEntry } from './router.js';
 import { logTransaction } from './debug-viewer.js';
 
 // ── Dice naming helpers ────────────────────────────────────────────────────────
@@ -340,6 +340,57 @@ function buildInjectedEntryText(id, entry, settings) {
     return `### [${label}]\n${content}\n\n`;
 }
 
+/**
+ * Builds the [NPC_RELATIONS] context block summarising current relationship standings
+ * for all active NPC lorebook entries. Injected at the top of each turn's context so
+ * the narrator knows where it stands with present characters before writing.
+ *
+ * Only includes NPCs whose lorebook book name ends with _npcs / _npc (case-insensitive).
+ * Returns an empty string if no relevant active entries exist.
+ *
+ * @param {ReturnType<typeof import('./state-manager.js').getSettings>} settings
+ * @returns {Promise<string>}
+ */
+async function buildNpcRelationsBlock(settings) {
+    if (!settings.npcRelationshipBars) return '';
+    const relVals = settings.npcRelationshipValues || {};
+    const activeKeys = settings.activeRouterKeys || [];
+    if (!activeKeys.length) return '';
+
+    const ctx = SillyTavern.getContext();
+    const lines = [];
+    /** @type {Record<string, any>} */
+    const bookCache = {};
+
+    for (const id of activeKeys) {
+        const [bookName, uid] = id.split('::');
+        if (!bookName || !uid) continue;
+        // Only NPC books
+        const bl = bookName.toLowerCase();
+        if (!bl.endsWith('_npcs') && !bl.endsWith('_npc') && bl !== 'npcs' && bl !== 'npc') continue;
+
+        if (!bookCache[bookName]) {
+            try { bookCache[bookName] = await ctx.loadWorldInfo(bookName); } catch (_) { bookCache[bookName] = null; }
+        }
+        const entry = bookCache[bookName]?.entries?.[uid];
+        if (!entry) continue;
+
+        // Strip [Major] / [Minor] prefix from comment to get the display name
+        const displayName = (entry.comment || '').replace(/^\[.*?\]\s*/i, '').trim();
+        if (!displayName) continue;
+
+        const rel = relVals[id] || { friendship: 0, affection: 0 };
+        const f = rel.friendship ?? 0;
+        const a = rel.affection ?? 0;
+        const fStr = `Friendship ${f >= 0 ? '+' : ''}${f}`;
+        const aStr = `Affection ${a >= 0 ? '+' : ''}${a}`;
+        lines.push(`${displayName}: ${fStr}, ${aStr}`);
+    }
+
+    if (!lines.length) return '';
+    return `[NPC_RELATIONS]\n${lines.join('\n')}\n[/NPC_RELATIONS]\n\n`;
+}
+
 export function installInterceptor() {
     globalThis.rpgTrackerInterceptor = async function (chat, contextSize, abort, type) {
         const settings = getSettings();
@@ -444,6 +495,13 @@ export function installInterceptor() {
         // In Path 1 (addPromptManagerInterceptor), these are built and injected by that interceptor
         // into a dedicated system message at the configured depth, protecting the prefix cache.
         if (!skipInjection) {
+            // [NPC_RELATIONS] block — prepended first so it has maximum salience in context.
+            // Shows the narrator current relationship standings for all active NPCs.
+            if (settings.npcRelationshipBars) {
+                const relBlock = await buildNpcRelationsBlock(settings);
+                if (relBlock) injections += relBlock;
+            }
+
             if (settings.rngEnabled && !content.includes("[RNG_QUEUE v6.0_PROPER]")) {
                 const queue = makeRngQueue(RNG_QUEUE_LEN);
                 injections += buildRngBlock(queue);
@@ -730,6 +788,191 @@ export function installInterceptor() {
 }
 
 
+// ── Relationship tag processor ─────────────────────────────────────────────────
+
+/**
+ * Processes [REL: Name | field | delta] tags emitted by the narrator AI.
+ *
+ * For each tag found in the last assistant message:
+ *  1. Resolves the NPC first-name to an active lorebook entry ID
+ *  2. Applies the delta to settings.npcRelationshipValues (clamped ±100)
+ *  3. Appends to settings.npcRelationshipLog with source:'ai'
+ *  4. Writes the updated values back to the lorebook entry (the persistent database)
+ *  5. Shows a toast notification
+ * Then strips all [REL: ...] tags from the visible message and refreshes the UI.
+ *
+ * Called as Step 0 of onGenerationEnded so bars update on EVERY turn, even when
+ * the Lorebook Agent is throttled.
+ */
+export async function processRelationshipTags() {
+    const settings = getSettings();
+    if (!settings.npcRelationshipBars || !settings.enabled) return;
+
+    const ctx = SillyTavern.getContext();
+    const chat = ctx.chat || [];
+
+    // Find the last assistant (non-user, non-system) message
+    let lastMsg = null;
+    for (let i = chat.length - 1; i >= 0; i--) {
+        if (!chat[i].is_user && !chat[i].is_system) { lastMsg = chat[i]; break; }
+    }
+    if (!lastMsg) return;
+
+    const rawText = lastMsg.mes || '';
+    if (!rawText.includes('[REL:')) return; // fast exit — no tags at all
+
+    const REL_RE = /\[REL:\s*([^|\]]+)\|\s*(friendship|affection)\s*\|\s*([+-]?\d+)\s*\]/gi;
+    const matches = [];
+    let m;
+    while ((m = REL_RE.exec(rawText)) !== null) {
+        const delta = parseInt(m[3], 10);
+        if (!isNaN(delta)) matches.push({ raw: m[0], name: m[1].trim(), field: m[2].toLowerCase(), delta });
+    }
+    if (!matches.length) return;
+
+    // ── Build first-name lookup from active NPC lorebook entries ──────────────
+    const activeKeys = settings.activeRouterKeys || [];
+    /** @type {Record<string, any>} */
+    const bookCache = {};
+    // firstNameMap: lowerCaseFirstName -> [{ id, displayName }]
+    /** @type {Record<string, Array<{id:string, displayName:string}>>} */
+    const firstNameMap = {};
+
+    for (const id of activeKeys) {
+        const [bookName, uid] = id.split('::');
+        if (!bookName || !uid) continue;
+        const bl = bookName.toLowerCase();
+        if (!bl.endsWith('_npcs') && !bl.endsWith('_npc') && bl !== 'npcs' && bl !== 'npc') continue;
+
+        if (!bookCache[bookName]) {
+            try { bookCache[bookName] = await ctx.loadWorldInfo(bookName); } catch (_) { bookCache[bookName] = null; }
+        }
+        const entry = bookCache[bookName]?.entries?.[uid];
+        if (!entry) continue;
+
+        const displayName = (entry.comment || '').replace(/^\[.*?\]\s*/i, '').trim();
+        if (!displayName) continue;
+
+        const firstName = displayName.split(/\s+/)[0].toLowerCase();
+        if (!firstNameMap[firstName]) firstNameMap[firstName] = [];
+        firstNameMap[firstName].push({ id, displayName });
+    }
+
+    // ── Process each match ────────────────────────────────────────────────────
+    let anyChanged = false;
+
+    for (const match of matches) {
+        if (match.delta === 0) continue;
+
+        // Resolve NPC name → entry ID
+        const nameLower = match.name.toLowerCase();
+        const candidates = firstNameMap[nameLower] || [];
+        let resolvedId = null;
+
+        if (candidates.length === 1) {
+            resolvedId = candidates[0].id;
+        } else if (candidates.length > 1) {
+            // Ambiguous first name — try exact full-name match
+            const full = candidates.find(c => c.displayName.toLowerCase() === nameLower);
+            if (full) resolvedId = full.id;
+            else {
+                if (settings.debugMode) console.warn(`[RPG Tracker] REL: ambiguous NPC name "${match.name}" (${candidates.length} matches) — skipping.`);
+                continue;
+            }
+        } else {
+            if (settings.debugMode) console.log(`[RPG Tracker] REL: NPC "${match.name}" not found in active NPC keys — skipping.`);
+            continue;
+        }
+
+        // Apply delta
+        if (!settings.npcRelationshipValues) settings.npcRelationshipValues = {};
+        if (!settings.npcRelationshipValues[resolvedId]) {
+            settings.npcRelationshipValues[resolvedId] = { friendship: 0, affection: 0 };
+        }
+        const prev = settings.npcRelationshipValues[resolvedId][match.field] ?? 0;
+        const newVal = Math.max(-100, Math.min(100, prev + match.delta));
+        settings.npcRelationshipValues[resolvedId][match.field] = newVal;
+
+        // Log entry
+        if (!settings.npcRelationshipLog) settings.npcRelationshipLog = {};
+        if (!settings.npcRelationshipLog[resolvedId]) settings.npcRelationshipLog[resolvedId] = [];
+        settings.npcRelationshipLog[resolvedId].unshift({
+            timestamp: Date.now(),
+            field: match.field,
+            delta: match.delta,
+            newValue: newVal,
+            source: 'ai',
+        });
+        if (settings.npcRelationshipLog[resolvedId].length > 50) {
+            settings.npcRelationshipLog[resolvedId].length = 50;
+        }
+
+        // Toast
+        const sign = match.delta > 0 ? '+' : '';
+        const icon = match.field === 'friendship' ? '🤝' : '💗';
+        const label = match.field === 'friendship' ? 'Friendship' : 'Affection';
+        // @ts-ignore
+        toastr.info(`${icon} ${match.name}: ${sign}${match.delta} ${label}`, 'Relationship', { timeOut: 3500, positionClass: 'toast-bottom-right' });
+
+        // ── Lorebook database write (async, fire-and-forget) ──────────────────
+        // Writes the updated values as a "Relationship:" line outside [CORE]
+        // so the Lorebook Agent has a persistent readable record.
+        const [bookName, uid] = resolvedId.split('::');
+        const relSnapshot = { ...settings.npcRelationshipValues[resolvedId] };
+        (async () => {
+            try {
+                const book = await ctx.loadWorldInfo(bookName);
+                if (!book?.entries?.[uid]) return;
+                const entry = book.entries[uid];
+                let content = entry.content || '';
+
+                const f = relSnapshot.friendship ?? 0;
+                const a = relSnapshot.affection ?? 0;
+                const relLine = `Relationship: Friendship ${f >= 0 ? '+' : ''}${f}, Affection ${a >= 0 ? '+' : ''}${a}`;
+
+                // Replace existing Relationship: line or append after content
+                if (/^Relationship:\s*Friendship/m.test(content)) {
+                    content = content.replace(/^Relationship:\s*Friendship[^\n]*/m, relLine);
+                } else {
+                    content = content.trimEnd() + '\n' + relLine;
+                }
+
+                await updateLorebookEntry(resolvedId, { content });
+                if (settings.debugMode) console.log(`[RPG Tracker] REL: wrote "${relLine}" to ${resolvedId}`);
+            } catch (e) {
+                console.warn('[RPG Tracker] REL: lorebook write failed:', e);
+            }
+        })();
+
+        anyChanged = true;
+    }
+
+    if (!anyChanged) return;
+
+    // ── Strip [REL: ...] tags from the visible message ────────────────────────
+    lastMsg.mes = rawText.replace(/\[REL:\s*[^|\]]+\|\s*(?:friendship|affection)\s*\|\s*[+-]?\d+\s*\]/gi, '').trimEnd();
+
+    // Update the rendered DOM so the stripped message is immediately visible
+    try {
+        const lastMesEl = /** @type {HTMLElement|null} */ (document.querySelector('#chat .mes:last-of-type .mes_text'));
+        if (lastMesEl) {
+            // Use the same render path SillyTavern uses: update innerText for the stripped tag lines
+            // A lightweight approach: remove any visible [REL: ...] text nodes
+            const html = lastMesEl.innerHTML;
+            const cleaned = html.replace(/\[REL:\s*[^|<]+\|\s*(?:friendship|affection)\s*\|\s*[+-]?\d+\s*\]/gi, '');
+            if (cleaned !== html) lastMesEl.innerHTML = cleaned;
+        }
+    } catch (_) { /* non-critical */ }
+
+    // Persist
+    ctx.saveSettingsDebounced?.();
+
+    // Refresh NPC card bars + manifest UI
+    if (typeof globalThis._rpgRenderRouterUI === 'function') globalThis._rpgRenderRouterUI();
+    document.dispatchEvent(new CustomEvent('rt_lore_agent_updated'));
+}
+
+
 // ── Narrative collector ────────────────────────────────────────────────────────
 
 /**
@@ -834,6 +1077,10 @@ export async function onGenerationEnded() {
     const { chat } = SillyTavern.getContext();
     const combinedNarrative = getNarrativeBlocks(chat, -1, !!settings.routerIncludeHidden);
     if (!combinedNarrative) return;
+
+    // Step 0: Process relationship tags — runs on EVERY generation, before all throttles,
+    // so bars update in real time even when the Lorebook Agent is idle.
+    await processRelationshipTags();
 
     if (settings.debugMode) console.log("[RPG Tracker] Assistant generation ended. Running keyword scanner...");
 

--- a/narrative-hooks.js
+++ b/narrative-hooks.js
@@ -380,6 +380,10 @@ function getAffectionTier(v) {
 }
 
 async function buildNpcRelationsBlock(settings) {
+    if (!settings.npcRelationshipBars) {
+        return '';
+    }
+
     const relVals = settings.npcRelationshipValues || {};
     const activeKeys = [...(settings.activeRouterKeys || []), ...(settings.activeWorldKeys || [])];
     

--- a/narrative-hooks.js
+++ b/narrative-hooks.js
@@ -394,7 +394,14 @@ async function buildNpcRelationsBlock(settings) {
         return `[NPC_RELATIONS]\nNo established relationships yet.\n[/NPC_RELATIONS]\n\n`;
     }
     
-    return `[NPC_RELATIONS]\n${lines.join('\n')}\n[/NPC_RELATIONS]\n\n`;
+    const header = [
+        `These are the current relationship standings between the protagonist and present NPCs.`,
+        `Friendship ranges from -100 (sworn enemy) to +100 (lifelong brother/sister). Affection ranges from -100 (revulsion) to +100 (deeply in love).`,
+        `Let these values organically influence how each NPC speaks, acts, and reacts toward the protagonist. Higher values mean warmer body language, more trust, inside jokes, and willingness to help. Lower values mean hostility, suspicion, cold formality, or outright antagonism.`,
+        `When a meaningful social interaction occurs that would shift an NPC's feelings, emit a tag at the end of your response: [REL: NpcName | friendship | +/-N] or [REL: NpcName | affection | +/-N] where N is typically 1-5 for minor moments and 5-15 for major events.`,
+    ].join('\n');
+
+    return `[NPC_RELATIONS]\n${header}\n\n${lines.join('\n')}\n[/NPC_RELATIONS]\n\n`;
 }
 
 export function installInterceptor() {
@@ -901,8 +908,55 @@ export async function processRelationshipTags() {
 
         ctx.saveSettingsDebounced?.();
         if (typeof globalThis._rpgRenderRouterUI === 'function') globalThis._rpgRenderRouterUI();
-        if (typeof globalThis._rpgRefreshNpcManifest === 'function') globalThis._rpgRefreshNpcManifest();
+        if (typeof globalThis._rpgRefreshAgentManifest === 'function') globalThis._rpgRefreshAgentManifest();
         document.dispatchEvent(new CustomEvent('rt_lore_agent_updated'));
+    }
+}
+
+/**
+ * Ensures a SillyTavern Regex Script exists to visually hide [REL: ...] tags from the
+ * rendered chat display. The tag remains in the raw message text (editable by pressing
+ * the edit button), so our parser and metadata deduplication continue to work. This
+ * only affects the visual render — it replaces the match with an empty string on
+ * "AI Output" and "Alter Chat Display" so the user never sees the raw tag in the
+ * conversation flow.
+ */
+export function ensureRelTagRegex() {
+    try {
+        const ctx = SillyTavern.getContext();
+        const extSettings = ctx.extensionSettings;
+        if (!extSettings) return;
+
+        // The regex extension stores scripts in extensionSettings.regex
+        if (!extSettings.regex) extSettings.regex = [];
+        const scripts = extSettings.regex;
+
+        const SCRIPT_NAME = 'Hide REL Tags [RPG Tracker]';
+
+        // Don't duplicate if already registered
+        if (scripts.some(s => s.scriptName === SCRIPT_NAME)) return;
+
+        scripts.push({
+            scriptName: SCRIPT_NAME,
+            findRegex: '/\\[REL:\\s*[^\\]]+\\]/g',
+            replaceString: '',
+            trimStrings: [],
+            placement: [
+                1, // AI_OUTPUT
+            ],
+            disabled: false,
+            markdownOnly: false,
+            promptOnly: false,
+            runOnEdit: true,
+            substituteRegex: false,
+            minDepth: null,
+            maxDepth: null,
+        });
+
+        ctx.saveSettingsDebounced?.();
+        console.log('[RPG Tracker] Registered REL tag hiding regex script.');
+    } catch (e) {
+        console.warn('[RPG Tracker] Could not register REL tag regex:', e);
     }
 }
 

--- a/narrative-hooks.js
+++ b/narrative-hooks.js
@@ -353,8 +353,8 @@ function buildInjectedEntryText(id, entry, settings) {
  */
 async function buildNpcRelationsBlock(settings) {
     const relVals = settings.npcRelationshipValues || {};
-    const activeKeys = settings.activeRouterKeys || [];
-    if (!activeKeys.length) return '';
+    const activeKeys = [...(settings.activeRouterKeys || []), ...(settings.activeWorldKeys || [])];
+    if (!activeKeys.length) return `[NPC_RELATIONS]\nNo established relationships yet.\n[/NPC_RELATIONS]\n\n`;
 
     const ctx = SillyTavern.getContext();
     const lines = [];
@@ -834,7 +834,7 @@ export async function processRelationshipTags() {
     // The map stores MULTIPLE keys per NPC: full name, each significant word (length > 2).
     // This resolves titled NPCs like "Ser Harys Swyft" whether the AI writes the full
     // name, a partial name, or just a given name.
-    const activeKeys = settings.activeRouterKeys || [];
+    const activeKeys = [...(settings.activeRouterKeys || []), ...(settings.activeWorldKeys || [])];
     /** @type {Record<string, any>} */
     const bookCache = {};
     /** @type {Record<string, Array<{id:string, displayName:string}>>} */

--- a/narrative-hooks.js
+++ b/narrative-hooks.js
@@ -389,7 +389,7 @@ async function buildNpcRelationsBlock(settings) {
         lines.push(`${displayName}: ${fStr}, ${aStr}`);
     }
 
-    if (!lines.length) return '';
+    if (!lines.length) return `[NPC_RELATIONS]\nNo established relationships yet.\n[/NPC_RELATIONS]\n\n`;
     return `[NPC_RELATIONS]\n${lines.join('\n')}\n[/NPC_RELATIONS]\n\n`;
 }
 

--- a/narrative-hooks.js
+++ b/narrative-hooks.js
@@ -354,11 +354,14 @@ function buildInjectedEntryText(id, entry, settings) {
 async function buildNpcRelationsBlock(settings) {
     const relVals = settings.npcRelationshipValues || {};
     const activeKeys = [...(settings.activeRouterKeys || []), ...(settings.activeWorldKeys || [])];
-    if (!activeKeys.length) return `[NPC_RELATIONS]\nNo established relationships yet.\n[/NPC_RELATIONS]\n\n`;
+    
+    // Always return the placeholder if no keys are active to ensure the AI knows the feature is ON.
+    if (!activeKeys.length) {
+        return `[NPC_RELATIONS]\nNo established relationships yet.\n[/NPC_RELATIONS]\n\n`;
+    }
 
     const ctx = SillyTavern.getContext();
     const lines = [];
-    /** @type {Record<string, any>} */
     const bookCache = {};
 
     for (const id of activeKeys) {
@@ -371,14 +374,12 @@ async function buildNpcRelationsBlock(settings) {
         const entry = bookCache[bookName]?.entries?.[uid];
         if (!entry) continue;
 
-        // Strip any leading [Tag] prefix to get the display name.
-        // We don't filter by prefix — any active entry that produces a displayName is included.
+        // Strip any bracketed prefixes from the comment to get a clean display name
         const rawComment = entry.comment || '';
         const displayName = rawComment.replace(/^\[.*?\]\s*/i, '').trim();
         if (!displayName) continue;
 
-        // Only include entries that already have relationship values tracked
-        // (avoids flooding the block with every single lorebook entry).
+        // Only include if they have a relationship tracked (prevents flooding context with non-NPC entries)
         if (!relVals[id]) continue;
 
         const rel = relVals[id];
@@ -389,7 +390,10 @@ async function buildNpcRelationsBlock(settings) {
         lines.push(`${displayName}: ${fStr}, ${aStr}`);
     }
 
-    if (!lines.length) return `[NPC_RELATIONS]\nNo established relationships yet.\n[/NPC_RELATIONS]\n\n`;
+    if (!lines.length) {
+        return `[NPC_RELATIONS]\nNo established relationships yet.\n[/NPC_RELATIONS]\n\n`;
+    }
+    
     return `[NPC_RELATIONS]\n${lines.join('\n')}\n[/NPC_RELATIONS]\n\n`;
 }
 
@@ -805,12 +809,13 @@ export function installInterceptor() {
  */
 export async function processRelationshipTags() {
     const settings = getSettings();
-    if (!settings.enabled) return;
+    if (!settings.enabled || settings.paused) return;
 
     const ctx = SillyTavern.getContext();
-    const chat = ctx.chat || [];
+    if (!ctx.chat || ctx.chat.length === 0) return;
+    const chat = ctx.chat;
 
-    // Find the last assistant (non-user, non-system) message
+    // Find the last assistant message
     let lastMsg = null;
     for (let i = chat.length - 1; i >= 0; i--) {
         if (!chat[i].is_user && !chat[i].is_system) { lastMsg = chat[i]; break; }
@@ -818,122 +823,93 @@ export async function processRelationshipTags() {
     if (!lastMsg) return;
 
     const rawText = lastMsg.mes || '';
-    if (!rawText.includes('[REL:')) return; // fast exit — no tags at all
+    if (!rawText.includes('[REL:')) return; // fast exit
 
+    // Strict regex exactly matching what the AI is told to output
     const REL_RE = /\[REL:\s*([^|\]]+)\|\s*(friendship|affection)\s*\|\s*([+-]?\d+)\s*\]/gi;
-    const matches = [];
-    let m;
-    while ((m = REL_RE.exec(rawText)) !== null) {
-        const delta = parseInt(m[3], 10);
-        if (!isNaN(delta)) matches.push({ raw: m[0], name: m[1].trim(), field: m[2].toLowerCase(), delta });
+    let matches = [];
+    let match;
+    while ((match = REL_RE.exec(rawText)) !== null) {
+        matches.push({ name: match[1].trim(), field: match[2].toLowerCase(), delta: parseInt(match[3], 10) });
     }
+
     if (!matches.length) return;
 
-    // ── Build multi-key name lookup from active NPC lorebook entries ──────────
-    // NPC entries are identified by [Major]/[Minor] comment prefix (framework standard).
-    // The map stores MULTIPLE keys per NPC: full name, each significant word (length > 2).
-    // This resolves titled NPCs like "Ser Harys Swyft" whether the AI writes the full
-    // name, a partial name, or just a given name.
+    // Combine all active keys from the state manager's tracking
     const activeKeys = [...(settings.activeRouterKeys || []), ...(settings.activeWorldKeys || [])];
-    /** @type {Record<string, any>} */
     const bookCache = {};
-    /** @type {Record<string, Array<{id:string, displayName:string}>>} */
-    const nameMap = {};
+    const activeEntries = [];
 
-    const _addToMap = (key, entry) => {
-        if (!key || key.length < 2) return;
-        if (!nameMap[key]) nameMap[key] = [];
-        nameMap[key].push(entry);
-    };
-
+    // Cache the active entries to search against
     for (const id of activeKeys) {
         const [bookName, uid] = id.split('::');
         if (!bookName || !uid) continue;
-
         if (!bookCache[bookName]) {
             try { bookCache[bookName] = await ctx.loadWorldInfo(bookName); } catch (_) { bookCache[bookName] = null; }
         }
         const entry = bookCache[bookName]?.entries?.[uid];
         if (!entry) continue;
 
+        // Clean the display name from the comment field
         const rawComment = entry.comment || '';
-        if (!rawComment) continue;
-
-        // Strip any leading [Tag] prefix (e.g. [Major], [Minor]) to get the display name.
-        // We do NOT filter by prefix — any active entry is a candidate.
         const displayName = rawComment.replace(/^\[.*?\]\s*/i, '').trim();
-        if (!displayName) continue;
+        
+        // Extract all keywords as an array of lowercase strings
+        const keywords = Array.isArray(entry.key) ? entry.key.map(k => k.toLowerCase().trim()) : [];
 
-        const rec = { id, displayName };
-        const nameLc = displayName.toLowerCase();
-
-        // Key 1: full display name ("ser harys swyft")
-        _addToMap(nameLc, rec);
-        // Key 2: each significant word (length > 2), so "harys", "swyft", "ser" all resolve
-        for (const word of nameLc.split(/\s+/)) {
-            if (word.length > 2) _addToMap(word, rec);
-        }
+        activeEntries.push({ id, displayName, keywords, comment: rawComment.toLowerCase() });
     }
 
-    // ── Process each match ────────────────────────────────────────────────────
     let anyChanged = false;
 
-    for (const match of matches) {
-        if (match.delta === 0) continue;
-
-        // Resolve NPC name → entry ID
-        // Strategy: exact full-name match first, then word-by-word fallback.
-        const nameLower = match.name.toLowerCase();
-
-        // Pass 1: exact match on the full tag name (handles "Ser Harys Swyft", "Elena", etc.)
-        let candidates = nameMap[nameLower] || [];
-
-        // Pass 2: word-by-word fallback — union of all candidates whose display name
-        // shares at least one significant word with the tag name.
-        if (!candidates.length) {
-            const tagWords = nameLower.split(/\s+/).filter(w => w.length > 2);
-            const seen = new Map();
-            for (const word of tagWords) {
-                for (const c of (nameMap[word] || [])) {
-                    if (!seen.has(c.id)) seen.set(c.id, c);
-                }
-            }
-            candidates = [...seen.values()];
-        }
-
+    for (const m of matches) {
+        if (m.delta === 0) continue;
+        
+        const targetName = m.name.toLowerCase();
         let resolvedId = null;
 
-        if (candidates.length === 1) {
-            resolvedId = candidates[0].id;
-        } else if (candidates.length > 1) {
-            // Ambiguous — prefer the candidate whose full display name most closely matches
-            const exact = candidates.find(c => c.displayName.toLowerCase() === nameLower);
-            if (exact) resolvedId = exact.id;
-            else {
-                if (settings.debugMode) console.warn(`[RPG Tracker] REL: ambiguous NPC name "${match.name}" (${candidates.length} matches) — skipping.`);
-                continue;
-            }
+        // PASS 1: Exact Display Name match
+        const exactMatch = activeEntries.find(e => e.displayName.toLowerCase() === targetName);
+        if (exactMatch) {
+            resolvedId = exactMatch.id;
         } else {
-            if (settings.debugMode) console.log(`[RPG Tracker] REL: NPC "${match.name}" not found in active NPC keys — skipping.`);
+            // PASS 2: Search within keywords
+            // The AI might output "Harys", and the keyword might be "Ser Harys Swyft"
+            const keywordMatch = activeEntries.find(e => 
+                e.keywords.some(k => k.includes(targetName) || targetName.includes(k))
+            );
+            if (keywordMatch) {
+                resolvedId = keywordMatch.id;
+            } else {
+                // PASS 3: Broad substring match against the raw comment
+                const commentMatch = activeEntries.find(e => e.comment.includes(targetName));
+                if (commentMatch) resolvedId = commentMatch.id;
+            }
+        }
+
+        if (!resolvedId) {
+            if (settings.debugMode) console.log(`[RPG Tracker] REL: Could not map "${m.name}" to any active entry.`);
+            // @ts-ignore
+            toastr.warning(`Could not map AI relationship tag for "${m.name}" to an active Lorebook entry.`, 'RPG Tracker');
             continue;
         }
 
-        // Apply delta
+        // Apply delta directly to the central settings state
         if (!settings.npcRelationshipValues) settings.npcRelationshipValues = {};
         if (!settings.npcRelationshipValues[resolvedId]) {
             settings.npcRelationshipValues[resolvedId] = { friendship: 0, affection: 0 };
         }
-        const prev = settings.npcRelationshipValues[resolvedId][match.field] ?? 0;
-        const newVal = Math.max(-100, Math.min(100, prev + match.delta));
-        settings.npcRelationshipValues[resolvedId][match.field] = newVal;
+        const prev = settings.npcRelationshipValues[resolvedId][m.field] ?? 0;
+        const newVal = Math.max(-100, Math.min(100, prev + m.delta));
+        settings.npcRelationshipValues[resolvedId][m.field] = newVal;
 
-        // Log entry
+        // Log entry for the UI history
         if (!settings.npcRelationshipLog) settings.npcRelationshipLog = {};
         if (!settings.npcRelationshipLog[resolvedId]) settings.npcRelationshipLog[resolvedId] = [];
         settings.npcRelationshipLog[resolvedId].unshift({
             timestamp: Date.now(),
-            field: match.field,
-            delta: match.delta,
+            field: m.field,
+            delta: m.delta,
             newValue: newVal,
             source: 'ai',
         });
@@ -941,69 +917,39 @@ export async function processRelationshipTags() {
             settings.npcRelationshipLog[resolvedId].length = 50;
         }
 
-        // Toast
-        const sign = match.delta > 0 ? '+' : '';
-        const icon = match.field === 'friendship' ? '🤝' : '💗';
-        const label = match.field === 'friendship' ? 'Friendship' : 'Affection';
+        // Toast success
+        const sign = m.delta > 0 ? '+' : '';
+        const icon = m.field === 'friendship' ? '🤝' : '💗';
+        const label = m.field === 'friendship' ? 'Friendship' : 'Affection';
         // @ts-ignore
-        toastr.info(`${icon} ${match.name}: ${sign}${match.delta} ${label}`, 'Relationship', { timeOut: 3500, positionClass: 'toast-bottom-right' });
-
-        // ── Lorebook database write (async, fire-and-forget) ──────────────────
-        // Writes the updated values as a "Relationship:" line outside [CORE]
-        // so the Lorebook Agent has a persistent readable record.
-        const [bookName, uid] = resolvedId.split('::');
-        const relSnapshot = { ...settings.npcRelationshipValues[resolvedId] };
-        (async () => {
-            try {
-                const book = await ctx.loadWorldInfo(bookName);
-                if (!book?.entries?.[uid]) return;
-                const entry = book.entries[uid];
-                let content = entry.content || '';
-
-                const f = relSnapshot.friendship ?? 0;
-                const a = relSnapshot.affection ?? 0;
-                const relLine = `Relationship: Friendship ${f >= 0 ? '+' : ''}${f}, Affection ${a >= 0 ? '+' : ''}${a}`;
-
-                // Replace existing Relationship: line or append after content
-                if (/^Relationship:\s*Friendship/m.test(content)) {
-                    content = content.replace(/^Relationship:\s*Friendship[^\n]*/m, relLine);
-                } else {
-                    content = content.trimEnd() + '\n' + relLine;
-                }
-
-                await updateLorebookEntry(resolvedId, { content });
-                if (settings.debugMode) console.log(`[RPG Tracker] REL: wrote "${relLine}" to ${resolvedId}`);
-            } catch (e) {
-                console.warn('[RPG Tracker] REL: lorebook write failed:', e);
-            }
-        })();
+        toastr.info(`${icon} ${m.name}: ${sign}${m.delta} ${label}`, 'Relationship', { timeOut: 3500, positionClass: 'toast-bottom-right' });
 
         anyChanged = true;
     }
 
-    if (!anyChanged) return;
-
-    // ── Strip [REL: ...] tags from the visible message ────────────────────────
+    // Always strip the tags from the visible message, even if no matches resolved.
+    // We do not want machine tags visible to the user or lingering in the chat context.
     lastMsg.mes = rawText.replace(/\[REL:\s*[^|\]]+\|\s*(?:friendship|affection)\s*\|\s*[+-]?\d+\s*\]/gi, '').trimEnd();
 
-    // Update the rendered DOM so the stripped message is immediately visible
+    // Update the DOM to hide it immediately
     try {
-        const lastMesEl = /** @type {HTMLElement|null} */ (document.querySelector('#chat .mes:last-of-type .mes_text'));
+        const lastMesEl = document.querySelector('#chat .mes:last-of-type .mes_text');
         if (lastMesEl) {
-            // Use the same render path SillyTavern uses: update innerText for the stripped tag lines
-            // A lightweight approach: remove any visible [REL: ...] text nodes
             const html = lastMesEl.innerHTML;
             const cleaned = html.replace(/\[REL:\s*[^|<]+\|\s*(?:friendship|affection)\s*\|\s*[+-]?\d+\s*\]/gi, '');
             if (cleaned !== html) lastMesEl.innerHTML = cleaned;
         }
-    } catch (_) { /* non-critical */ }
+    } catch (_) {}
 
-    // Persist
-    ctx.saveSettingsDebounced?.();
-
-    // Refresh NPC card bars + manifest UI
-    if (typeof globalThis._rpgRenderRouterUI === 'function') globalThis._rpgRenderRouterUI();
-    document.dispatchEvent(new CustomEvent('rt_lore_agent_updated'));
+    // Persist modifications to chat history
+    if (typeof ctx.saveChatDebounced === 'function') ctx.saveChatDebounced();
+    
+    if (anyChanged) {
+        ctx.saveSettingsDebounced?.();
+        // Force the Campaign Records UI to rerender and show the new relationship bars
+        if (typeof globalThis._rpgRenderRouterUI === 'function') globalThis._rpgRenderRouterUI();
+        document.dispatchEvent(new CustomEvent('rt_lore_agent_updated'));
+    }
 }
 
 

--- a/narrative-hooks.js
+++ b/narrative-hooks.js
@@ -809,14 +809,23 @@ export async function processRelationshipTags() {
     const matches = [];
     let match;
     
+    // Ensure the message has an extra metadata dictionary for tracking processed tags
+    lastMsg.extra = lastMsg.extra || {};
+    lastMsg.extra.rpgProcessedTags = lastMsg.extra.rpgProcessedTags || [];
+
     while ((match = REL_RE.exec(lastMsg.mes)) !== null) {
+        const matchStr = match[0];
+        
+        // Skip if this exact tag string has already been processed for this message
+        if (lastMsg.extra.rpgProcessedTags.includes(matchStr)) continue;
+
         const cleanName = match[1].replace(/[\u200B\uFEFF]/g, '').trim();
         const cleanField = match[2].replace(/[^a-z]/gi, '').toLowerCase();
         const cleanDeltaStr = match[3].replace(/[^\d+-]/g, '');
         const parsedDelta = parseInt(cleanDeltaStr, 10);
 
         if ((cleanField === 'friendship' || cleanField === 'affection') && !isNaN(parsedDelta)) {
-            matches.push({ name: cleanName, field: cleanField, delta: parsedDelta });
+            matches.push({ name: cleanName, field: cleanField, delta: parsedDelta, rawStr: matchStr });
         }
     }
 
@@ -876,6 +885,8 @@ export async function processRelationshipTags() {
             // @ts-ignore
             toastr.info(`${icon} ${m.name}: ${sign}${m.delta} ${label}`, 'Relationship', { timeOut: 3500, positionClass: 'toast-bottom-right' });
 
+            // Mark this specific tag string as processed in the message metadata
+            lastMsg.extra.rpgProcessedTags.push(m.rawStr);
             anyChanged = true;
         } catch (e) {
             console.error('[RPG Tracker] Error updating relationship for', m.name, e);
@@ -885,8 +896,7 @@ export async function processRelationshipTags() {
     }
 
     if (anyChanged) {
-        // Prevent infinite allocations on manual edits/swipes by renaming the processed tag
-        lastMsg.mes = lastMsg.mes.replace(/\[REL:/gi, '[PROCESSED_REL:');
+        // Persist the message metadata so it survives reloads
         if (typeof ctx.saveChatDebounced === 'function') ctx.saveChatDebounced();
 
         ctx.saveSettingsDebounced?.();

--- a/narrative-hooks.js
+++ b/narrative-hooks.js
@@ -862,6 +862,12 @@ export async function processRelationshipTags() {
         if (!settings.npcRelationshipLog[resolved.id]) settings.npcRelationshipLog[resolved.id] = [];
         settings.npcRelationshipLog[resolved.id].unshift({ timestamp: Date.now(), field: m.field, delta: m.delta, newValue: settings.npcRelationshipValues[resolved.id][m.field], source: 'ai' });
         
+        const sign = m.delta > 0 ? '+' : '';
+        const icon = m.field === 'friendship' ? '🤝' : '💗';
+        const label = m.field === 'friendship' ? 'Friendship' : 'Affection';
+        // @ts-ignore
+        toastr.info(`${icon} ${m.name}: ${sign}${m.delta} ${label}`, 'Relationship', { timeOut: 3500, positionClass: 'toast-bottom-right' });
+
         anyChanged = true;
     }
 

--- a/narrative-hooks.js
+++ b/narrative-hooks.js
@@ -841,7 +841,7 @@ export async function processRelationshipTags(msgIndex) {
         lastMsg = ctx.chat[msgIndex];
     } else {
         // Scan from end backwards, skipping user messages, until we find one with [REL:]
-        for (let i = ctx.chat.length - 1; i >= Math.max(0, ctx.chat.length - 5); i--) {
+        for (let i = ctx.chat.length - 1; i >= Math.max(0, ctx.chat.length - 2); i--) {
             const msg = ctx.chat[i];
             if (msg && !msg.is_user && msg.mes && /\[REL:/i.test(msg.mes)) {
                 lastMsg = msg;

--- a/narrative-hooks.js
+++ b/narrative-hooks.js
@@ -832,22 +832,14 @@ export async function processRelationshipTags(msgIndex) {
     if (!ctx.chat || ctx.chat.length === 0) return;
     
     // Resolve the target message.
-    // If called from MESSAGE_UPDATED, msgIndex is the exact message to check.
-    // If called from GENERATION_ENDED (no index), scan backwards for the last
-    // AI message that actually contains a [REL:] tag — avoids the race where
-    // chat.length-1 is still the user's turn when the event fires.
+    // MESSAGE_UPDATED passes the exact index \u2014 use it directly.
+    // GENERATION_ENDED calls with no index; the setTimeout in onGenerationEnded
+    // guarantees ST has committed the AI message by now, so chat.length-1 is safe.
     let lastMsg;
     if (typeof msgIndex === 'number' && msgIndex >= 0 && msgIndex < ctx.chat.length) {
         lastMsg = ctx.chat[msgIndex];
     } else {
-        // Scan from end backwards, skipping user messages, until we find one with [REL:]
-        for (let i = ctx.chat.length - 1; i >= Math.max(0, ctx.chat.length - 2); i--) {
-            const msg = ctx.chat[i];
-            if (msg && !msg.is_user && msg.mes && /\[REL:/i.test(msg.mes)) {
-                lastMsg = msg;
-                break;
-            }
-        }
+        lastMsg = ctx.chat[ctx.chat.length - 1];
     }
     if (!lastMsg || !lastMsg.mes) return;
     if (!/\[REL:/i.test(lastMsg.mes)) return;

--- a/narrative-hooks.js
+++ b/narrative-hooks.js
@@ -351,6 +351,34 @@ const label = entry.key?.[0] || entry.comment || id.split('::')[1];
  * @param {ReturnType<typeof import('./state-manager.js').getSettings>} settings
  * @returns {Promise<string>}
  */
+/**
+ * Maps a friendship value (-100..+100) to a tier label and short behavioral hint.
+ * Pure code — no LLM dependency.
+ */
+function getFriendshipTier(v) {
+    if (v <= -60) return { label: 'HOSTILE',            hint: 'open contempt, refuses cooperation, may sabotage or attack' };
+    if (v <= -30) return { label: 'COLD/DISTRUSTFUL',   hint: 'curt and guarded, answers with bare minimum, visible irritation' };
+    if (v <= -1)  return { label: 'WARY/UNEASY',        hint: 'polite but distant, avoids personal topics, second-guesses motives' };
+    if (v <= 15)  return { label: 'NEUTRAL/ACQUAINTANCE',hint: 'civil and transactional, neither warm nor cold' };
+    if (v <= 40)  return { label: 'FRIENDLY',            hint: 'genuine warmth, light humor, willing to help when asked' };
+    if (v <= 70)  return { label: 'CLOSE FRIEND',        hint: 'deep trust, confides worries, stands up for {{user}}, proactive help' };
+    return                { label: 'BONDED/FAMILY',      hint: 'unbreakable loyalty, would risk life without hesitation, shares deepest secrets' };
+}
+
+/**
+ * Maps an affection value (-100..+100) to a tier label and short behavioral hint.
+ * Pure code — no LLM dependency.
+ */
+function getAffectionTier(v) {
+    if (v <= -60) return { label: 'REVULSION',              hint: 'finds {{user}} repulsive, recoils from proximity, hostile to any advance' };
+    if (v <= -30) return { label: 'AVERSION',               hint: 'clearly uninterested, dismisses flirtation coldly, steers away from intimacy' };
+    if (v <= -1)  return { label: 'INDIFFERENT/UNINTERESTED',hint: 'no romantic spark, gentle deflection of any advances' };
+    if (v <= 15)  return { label: 'NEUTRAL CURIOSITY',      hint: 'no feelings formed yet, might notice {{user}} but won\'t act on it' };
+    if (v <= 40)  return { label: 'INTERESTED',             hint: 'steals glances, responds warmly to compliments, comfortable with proximity' };
+    if (v <= 70)  return { label: 'ATTRACTED',              hint: 'seeks {{user}}\'s company, flustered by bold compliments, visible tension' };
+    return                { label: 'DEEPLY IN LOVE',        hint: 'emotionally devoted, craves closeness, expresses tenderness openly' };
+}
+
 async function buildNpcRelationsBlock(settings) {
     const relVals = settings.npcRelationshipValues || {};
     const activeKeys = [...(settings.activeRouterKeys || []), ...(settings.activeWorldKeys || [])];
@@ -387,67 +415,18 @@ async function buildNpcRelationsBlock(settings) {
         const a = rel.affection ?? 0;
         const fStr = `Friendship ${f >= 0 ? '+' : ''}${f}`;
         const aStr = `Affection ${a >= 0 ? '+' : ''}${a}`;
-        lines.push(`${displayName}: ${fStr}, ${aStr}`);
+        const fTier = getFriendshipTier(f);
+        const aTier = getAffectionTier(a);
+        lines.push(`${displayName}: ${fStr}, ${aStr}\n  Friendship tier: ${fTier.label} — ${fTier.hint}\n  Affection tier: ${aTier.label} — ${aTier.hint}`);
     }
 
     if (!lines.length) {
         return `[NPC_RELATIONS]\nNo established relationships yet.\n[/NPC_RELATIONS]\n\n`;
     }
     
-    const header = [
-        `These are the current relationship standings between the protagonist and present NPCs.`,
-        `Both Friendship and Affection range from -100 to +100. These values MUST organically, subtly, and pervasively influence how every NPC speaks, acts, reacts, and behaves toward the protagonist in EVERY interaction — not just explicitly social ones.`,
-        ``,
-        `<FRIENDSHIP_TIERS>`,
-        `Friendship reflects trust, camaraderie, and mutual respect.`,
-        `-100 to -60 (HOSTILE): The NPC despises the protagonist. They refuse cooperation, speak with open contempt or threats, may actively sabotage or attack. Greetings are met with hostility ("You dare show your face here?"). Requests are flatly denied or mocked. They warn others against the protagonist.`,
-        `-59 to -30 (COLD/DISTRUSTFUL): The NPC dislikes the protagonist. Conversations are curt, dismissive, and guarded. They answer questions with the bare minimum, refuse favors, and show visible irritation. Body language is closed off — crossed arms, averted gaze, terse replies. They may comply under duress but resent it.`,
-        `-29 to -1 (WARY/UNEASY): The NPC is uncomfortable around the protagonist. Polite but distant, they keep interactions short, avoid personal topics, and maintain emotional walls. Trust must be earned — they second-guess motives and hedge their words.`,
-        `0 to +15 (NEUTRAL/ACQUAINTANCE): Standard professional courtesy. The NPC is neither warm nor cold — transactional and civil. They'll answer questions straightforwardly but won't volunteer information or go out of their way.`,
-        `+16 to +40 (FRIENDLY): The NPC genuinely likes the protagonist. Conversations flow naturally with warmth, light humor, and willingness to share. They offer unsolicited advice, remember past encounters fondly, and are inclined to help when asked. Greetings are warm ("Good to see you again!").`,
-        `+41 to +70 (CLOSE FRIEND): Deep mutual trust. The NPC shares personal stories, confides worries, and stands up for the protagonist in front of others. They offer help proactively, make sacrifices, and joke with familiar intimacy. In danger, they prioritize the protagonist's safety.`,
-        `+71 to +100 (BONDED/FAMILY): Near-unbreakable loyalty. The NPC treats the protagonist like a sibling or lifelong companion. They would risk their life without hesitation, share their deepest secrets, and defend the protagonist's honor fiercely. Conversations are effortless, filled with inside jokes and unspoken understanding.`,
-        `</FRIENDSHIP_TIERS>`,
-        ``,
-        `<AFFECTION_TIERS>`,
-        `Affection reflects romantic/physical attraction and emotional intimacy beyond friendship.`,
-        `-100 to -60 (REVULSION): The NPC finds the protagonist repulsive or deeply off-putting. Any flirtation is met with disgust, anger, or fear. They recoil from physical proximity and may feel threatened by romantic advances.`,
-        `-59 to -30 (AVERSION): The NPC is clearly uninterested and uncomfortable with any romantic subtext. Flirtation is dismissed coldly or with visible cringe. They actively steer conversations away from anything personal or intimate.`,
-        `-29 to -1 (INDIFFERENT/UNINTERESTED): No romantic spark. The NPC treats flirtation as awkward or misplaced but isn't hostile about it — more of a gentle deflection or confused look.`,
-        `0 to +15 (NEUTRAL CURIOSITY): The NPC hasn't formed romantic feelings but isn't closed off. They might blush faintly at a well-placed compliment or notice the protagonist's appearance without acting on it.`,
-        `+16 to +40 (INTERESTED): The NPC is visibly intrigued. They steal glances, respond warmly to compliments, and may initiate light flirtation themselves. Physical proximity doesn't bother them — they might lean in during conversation, touch an arm casually, or linger during goodbyes.`,
-        `+41 to +70 (ATTRACTED): Strong romantic interest. The NPC seeks out the protagonist's company, becomes flustered by bold compliments, and shows jealousy when the protagonist flirts with others. Physical tension is palpable — lingering eye contact, finding excuses to be near, playful banter with romantic undertones.`,
-        `+71 to +100 (DEEPLY IN LOVE): The NPC is emotionally devoted. They express tenderness openly, prioritize the protagonist's emotional wellbeing, and crave physical and emotional closeness. Vulnerability comes naturally, and they may express their feelings through actions (gifts, protection, grand gestures) even if they struggle to say it directly.`,
-        `</AFFECTION_TIERS>`,
-        ``,
-        `<BEHAVIORAL_RULES>`,
-        `These tiers are NOT rigid thresholds — they are a spectrum. Blend behaviors fluidly based on the exact value. An NPC at +38 friendship should act distinctly different from one at +65.`,
-        `EVERY scene should reflect these values: how NPCs greet the protagonist, how they respond to requests, how they behave in combat alongside or against them, how they react to danger, how they speak in group settings, what information they volunteer, and whether they show vulnerability.`,
-        `NPCs with high friendship but low affection treat the protagonist like a trusted comrade — warm but platonic. NPCs with high affection but low friendship might be attracted but distrustful — flirtatious yet guarded. Both values together create a unique behavioral fingerprint for each NPC.`,
-        `</BEHAVIORAL_RULES>`,
-        ``,
-        `<RELATIONSHIP_ALLOCATION>`,
-        `When a meaningful interaction occurs that would realistically shift an NPC's feelings, emit a tag at the END of your response:`,
-        `[REL: NpcName | friendship | +/-N] or [REL: NpcName | affection | +/-N]`,
-        ``,
-        `WHEN TO ALLOCATE (non-exhaustive — use judgment for ALL situations):`,
-        `• Direct compliments, insults, gifts, or threats (+/-1 to 5)`,
-        `• Sharing a meal, campfire conversation, bonding over shared interests (+1 to 3 friendship)`,
-        `• Surviving danger together, completing a quest as allies (+3 to 8 friendship)`,
-        `• Betrayal, breaking a promise, abandoning them in danger (-5 to -15 friendship)`,
-        `• Saving their life or a loved one's life (+8 to 15 friendship)`,
-        `• Flirtatious banter received well (+1 to 3 affection), received poorly (-1 to -3 affection)`,
-        `• A meaningful personal confession or vulnerable moment (+3 to 6 affection)`,
-        `• A romantic gesture — a dance, a gift with personal significance, a protective act (+4 to 8 affection)`,
-        `• Spending extended quality time together with positive interactions (+2 to 4 of either or both)`,
-        `• Disrespecting their values, culture, or loved ones (-3 to -10 friendship)`,
-        `• Ignoring them, forgetting something important to them (-1 to -3 friendship)`,
-        `These are EXAMPLES. Adapt your judgment to any situation. The magnitude should reflect the NPC's personality — a stoic warrior might give +1 where a warm innkeeper gives +3 for the same compliment.`,
-        `Typical range: 1-5 for minor moments, 5-15 for major events. Only use 15+ for life-altering moments.`,
-        `</RELATIONSHIP_ALLOCATION>`,
-    ].join('\n');
+    const header = `Current relationship standings between the protagonist and present NPCs. Both axes range from -100 to +100. Let the tier descriptions below each NPC guide how they behave toward {{user}} this turn.`;
 
-    return `[NPC_RELATIONS]\n${header}\n\n${lines.join('\n')}\n[/NPC_RELATIONS]\n\n`;
+    return `[NPC_RELATIONS]\n${header}\n\n${lines.join('\n\n')}\n[/NPC_RELATIONS]\n\n`;
 }
 
 export function installInterceptor() {

--- a/narrative-hooks.js
+++ b/narrative-hooks.js
@@ -325,9 +325,17 @@ function extractTextContent(msg) {
 
 /**
  * Formats a lorebook entry block for injection into the GM/narrator prompt.
+ * Automatically prepends any active NPC relationship status values if relationship bars are enabled.
  */
 function buildInjectedEntryText(id, entry, settings) {
     let content = entry.content || '';
+    const rel = settings.npcRelationshipValues?.[id];
+    if (rel && settings.npcRelationshipBars) {
+        const friendship = rel.friendship ?? 0;
+        const affection = rel.affection ?? 0;
+        // Inject relationship values immediately below the entity header
+        content = `Relationship with {{user}}: Friendship: ${friendship}/100, Affection: ${affection}/100\n${content}`;
+    }
     const label = entry.key?.[0] || entry.comment || id.split('::')[1];
     return `### [${label}]\n${content}\n\n`;
 }

--- a/narrative-hooks.js
+++ b/narrative-hooks.js
@@ -827,22 +827,34 @@ export function installInterceptor() {
  */
 export async function processRelationshipTags(msgIndex) {
     const settings = getSettings();
+    console.log('[RPG Tracker] processRelationshipTags called with msgIndex:', msgIndex);
 
     const ctx = SillyTavern.getContext();
-    if (!ctx.chat || ctx.chat.length === 0) return;
+    if (!ctx.chat || ctx.chat.length === 0) {
+        console.log('[RPG Tracker] Aborting: ctx.chat is empty');
+        return;
+    }
     
     // Resolve the target message.
-    // MESSAGE_UPDATED passes the exact index \u2014 use it directly.
-    // GENERATION_ENDED calls with no index; the setTimeout in onGenerationEnded
-    // guarantees ST has committed the AI message by now, so chat.length-1 is safe.
     let lastMsg;
     if (typeof msgIndex === 'number' && msgIndex >= 0 && msgIndex < ctx.chat.length) {
         lastMsg = ctx.chat[msgIndex];
+        console.log('[RPG Tracker] Using provided msgIndex:', msgIndex);
     } else {
         lastMsg = ctx.chat[ctx.chat.length - 1];
+        console.log('[RPG Tracker] Using chat.length - 1:', ctx.chat.length - 1);
     }
-    if (!lastMsg || !lastMsg.mes) return;
-    if (!/\[REL:/i.test(lastMsg.mes)) return;
+    
+    if (!lastMsg || !lastMsg.mes) {
+        console.log('[RPG Tracker] Aborting: lastMsg or lastMsg.mes is empty');
+        return;
+    }
+    if (!/\[REL:/i.test(lastMsg.mes)) {
+        console.log('[RPG Tracker] Aborting: lastMsg.mes does not contain [REL:');
+        return;
+    }
+
+    console.log('[RPG Tracker] [REL:] tag found in message!', lastMsg.mes);
 
     // 2. Extracts data using indestructible regex
     const REL_RE = /\[REL:\s*([^|]+)\|\s*([^|]+)\|\s*([^\]]+)\]/gi;
@@ -866,10 +878,16 @@ export async function processRelationshipTags(msgIndex) {
 
         if ((cleanField === 'friendship' || cleanField === 'affection') && !isNaN(parsedDelta)) {
             matches.push({ name: cleanName, field: cleanField, delta: parsedDelta, rawStr: matchStr });
+            console.log('[RPG Tracker] Parsed match:', { name: cleanName, field: cleanField, delta: parsedDelta });
+        } else {
+            console.log('[RPG Tracker] Failed to parse match:', matchStr, { cleanField, parsedDelta });
         }
     }
 
-    if (matches.length === 0) return;
+    if (matches.length === 0) {
+        console.log('[RPG Tracker] Aborting: matches.length === 0 after parsing');
+        return;
+    }
 
     // Load active entries to resolve NPC IDs
     const activeKeys = [...(settings.activeRouterKeys || []), ...(settings.activeWorldKeys || [])];

--- a/narrative-hooks.js
+++ b/narrative-hooks.js
@@ -817,12 +817,6 @@ export async function processRelationshipTags() {
         let msgHasMatch = false;
         
         const newMes = msg.mes.replace(REL_RE, (matchStr, name, field, delta, offset, fullString) => {
-            // Ignore if already inside an HTML comment
-            const before = fullString.substring(0, offset);
-            if (before.lastIndexOf('<!--') > before.lastIndexOf('-->')) {
-                return matchStr; // Return unchanged
-            }
-
             // Clean the extracted values to be completely indestructible against LLM formatting quirks
             const cleanName = name.replace(/[\u200B\uFEFF]/g, '').trim();
             const cleanField = field.replace(/[^a-z]/gi, '').toLowerCase();
@@ -836,8 +830,19 @@ export async function processRelationshipTags() {
                     delta: parsedDelta 
                 });
                 msgHasMatch = true;
-                // Wrap in standard HTML comments so it is natively hidden by the Markdown parser
-                return `<!-- ${matchStr} -->`;
+                
+                // Mark as processed to prevent infinite loops on rescans
+                const processedStr = matchStr.replace(/\[REL:/i, '[PROCESSED_REL:');
+                
+                // If it is ALREADY inside an HTML comment (e.g. generated inside <!--TRACKER:), 
+                // do NOT wrap it again to prevent illegal nested comments.
+                const before = fullString.substring(0, offset);
+                if (before.lastIndexOf('<!--') > before.lastIndexOf('-->')) {
+                    return processedStr; 
+                }
+
+                // If it's visible text, wrap it in standard HTML comments so ST hides it natively
+                return `<!-- ${processedStr} -->`;
             }
 
             return matchStr; // If it was malformed beyond repair, don't touch it
@@ -875,9 +880,10 @@ export async function processRelationshipTags() {
         for (const el of lastMesEls) {
             if (el.innerHTML.includes('[REL:')) {
                 el.innerHTML = el.innerHTML.replace(REL_RE, (matchStr, name, field, delta, offset, fullString) => {
+                    const processedStr = matchStr.replace(/\[REL:/i, '[PROCESSED_REL:');
                     const before = fullString.substring(0, offset);
-                    if (before.lastIndexOf('<!--') > before.lastIndexOf('-->')) return matchStr;
-                    return `<!--TRACKER: ${matchStr}-->`;
+                    if (before.lastIndexOf('<!--') > before.lastIndexOf('-->')) return processedStr;
+                    return `<!-- ${processedStr} -->`;
                 });
             }
         }

--- a/narrative-hooks.js
+++ b/narrative-hooks.js
@@ -801,8 +801,8 @@ export async function processRelationshipTags() {
     if (!ctx.chat || ctx.chat.length === 0) return;
     const chat = ctx.chat;
 
-    // Regex matches [REL: Name | field | delta] but IGNORES ones already wrapped in <!-- -->
-    const REL_RE = /(?<!<!--\s*)\[REL:\s*([^|\]]+)\|\s*(friendship|affection)\s*\|\s*([+-]?\s*\d+)\s*\]/gi;
+    // Standard regex matches [REL: Name | field | delta]
+    const REL_RE = /\[REL:\s*([^|\]]+)\|\s*(friendship|affection)\s*\|\s*([+-]?\s*\d+)\s*\]/gi;
     
     const matches = [];
     let lastMsg = null;
@@ -814,17 +814,29 @@ export async function processRelationshipTags() {
         if (!msg || !msg.mes) continue;
         if (!msg.mes.includes('[REL:')) continue;
 
-        let match;
         let msgHasMatch = false;
-        while ((match = REL_RE.exec(msg.mes)) !== null) {
-            matches.push({ name: match[1].trim(), field: match[2].toLowerCase(), delta: parseInt(match[3].replace(/\s+/g, ''), 10) });
+        
+        const newMes = msg.mes.replace(REL_RE, (matchStr, name, field, delta, offset, fullString) => {
+            // Ignore if already inside an HTML comment
+            const before = fullString.substring(0, offset);
+            if (before.lastIndexOf('<!--') > before.lastIndexOf('-->')) {
+                return matchStr; // Return unchanged
+            }
+
+            matches.push({ 
+                name: name.trim(), 
+                field: field.toLowerCase(), 
+                delta: parseInt(delta.replace(/\s+/g, ''), 10) 
+            });
             msgHasMatch = true;
-        }
+
+            // Wrap in <!--TRACKER: to integrate with the user's regex preset
+            return `<!--TRACKER: ${matchStr}-->`;
+        });
 
         if (msgHasMatch) {
-            // Always WRAP the tags in HTML comments so they are hidden from the user but remain in the context
-            msg.mes = msg.mes.replace(REL_RE, (m) => `<!-- ${m} -->`).trimEnd();
-            lastMsg = msg; // Track that we modified at least one message
+            msg.mes = newMes.trimEnd();
+            lastMsg = msg;
         }
     }
 
@@ -849,11 +861,15 @@ export async function processRelationshipTags() {
     }
 
     try {
-        // Also force the DOM to hide it immediately if it's in the last message
+        // Force the DOM to hide it immediately if it's in the last message
         const lastMesEls = document.querySelectorAll('#chat .mes .mes_text');
         for (const el of lastMesEls) {
             if (el.innerHTML.includes('[REL:')) {
-                el.innerHTML = el.innerHTML.replace(REL_RE, (m) => `<!-- ${m} -->`);
+                el.innerHTML = el.innerHTML.replace(REL_RE, (matchStr, name, field, delta, offset, fullString) => {
+                    const before = fullString.substring(0, offset);
+                    if (before.lastIndexOf('<!--') > before.lastIndexOf('-->')) return matchStr;
+                    return `<!--TRACKER: ${matchStr}-->`;
+                });
             }
         }
     } catch (_) {}

--- a/narrative-hooks.js
+++ b/narrative-hooks.js
@@ -795,7 +795,6 @@ export function installInterceptor() {
  */
 export async function processRelationshipTags() {
     const settings = getSettings();
-    if (!settings.enabled || settings.paused) return;
 
     const ctx = SillyTavern.getContext();
     if (!ctx.chat || ctx.chat.length === 0) return;
@@ -977,12 +976,9 @@ export function resetRouterTick(clearKeywordPool = false) {
 export async function onGenerationEnded() {
     const settings = getSettings();
 
-    // Step 0: Relationship tag processing — runs FIRST, before all other guards
-    // (isStateRunning, combinedNarrative, throttles). This guarantees bars update
-    // on every single generation regardless of any other system state.
-    if (settings.enabled && !settings.paused) {
-        await processRelationshipTags();
-    }
+    // Step 0: Relationship tag processing - runs FIRST, unconditionally.
+    // This guarantees bars update on every single generation even if the main lore agent is paused.
+    await processRelationshipTags();
 
     const isStateRunning = typeof globalThis._rpgStateModelRunning === 'function' && globalThis._rpgStateModelRunning();
     if (!settings.enabled || settings.paused || isStateRunning) return;

--- a/narrative-hooks.js
+++ b/narrative-hooks.js
@@ -801,8 +801,8 @@ export async function processRelationshipTags() {
     if (!ctx.chat || ctx.chat.length === 0) return;
     const chat = ctx.chat;
 
-    // Standard regex matches [REL: Name | field | delta]
-    const REL_RE = /\[REL:\s*([^|\]]+)\|\s*(friendship|affection)\s*\|\s*([+-]?\s*\d+)\s*\]/gi;
+    // Indestructible regex: Matches [REL: A | B | C] regardless of spacing, case, or invisible chars
+    const REL_RE = /\[REL:\s*([^|]+)\|\s*([^|]+)\|\s*([^\]]+)\]/gi;
     
     const matches = [];
     let lastMsg = null;
@@ -812,7 +812,7 @@ export async function processRelationshipTags() {
     for (let i = chat.length - 1; i >= Math.max(0, chat.length - 3); i--) {
         const msg = chat[i];
         if (!msg || !msg.mes) continue;
-        if (!msg.mes.includes('[REL:')) continue;
+        if (!/\[REL:/i.test(msg.mes)) continue;
 
         let msgHasMatch = false;
         
@@ -823,15 +823,24 @@ export async function processRelationshipTags() {
                 return matchStr; // Return unchanged
             }
 
-            matches.push({ 
-                name: name.trim(), 
-                field: field.toLowerCase(), 
-                delta: parseInt(delta.replace(/\s+/g, ''), 10) 
-            });
-            msgHasMatch = true;
+            // Clean the extracted values to be completely indestructible against LLM formatting quirks
+            const cleanName = name.replace(/[\u200B\uFEFF]/g, '').trim();
+            const cleanField = field.replace(/[^a-z]/gi, '').toLowerCase();
+            const cleanDeltaStr = delta.replace(/[^\d+-]/g, '');
+            const parsedDelta = parseInt(cleanDeltaStr, 10);
 
-            // Wrap in <!--TRACKER: to integrate with the user's regex preset
-            return `<!--TRACKER: ${matchStr}-->`;
+            if ((cleanField === 'friendship' || cleanField === 'affection') && !isNaN(parsedDelta)) {
+                matches.push({ 
+                    name: cleanName, 
+                    field: cleanField, 
+                    delta: parsedDelta 
+                });
+                msgHasMatch = true;
+                // Wrap in <!--TRACKER: to integrate with the user's regex preset
+                return `<!--TRACKER: ${matchStr}-->`;
+            }
+
+            return matchStr; // If it was malformed beyond repair, don't touch it
         });
 
         if (msgHasMatch) {

--- a/narrative-hooks.js
+++ b/narrative-hooks.js
@@ -849,8 +849,63 @@ export async function processRelationshipTags(msgIndex) {
         console.log('[RPG Tracker] Aborting: lastMsg or lastMsg.mes is empty');
         return;
     }
+
+    let anyChanged = false;
+    const triggerUIUpdate = () => {
+        if (typeof ctx.saveChatDebounced === 'function') ctx.saveChatDebounced();
+        ctx.saveSettingsDebounced?.();
+        if (typeof globalThis._rpgRenderRouterUI === 'function') globalThis._rpgRenderRouterUI();
+        refreshRelationshipBarsDOM(settings);
+        document.dispatchEvent(new CustomEvent('rt_lore_agent_updated'));
+    };
+
+    // --- 1. SWIPE ROLLBACK & INITIALIZATION ---
+    lastMsg.extra = lastMsg.extra || {};
+    const swipeId = lastMsg.swipe_id ?? 0;
+
+    // Convert old array format to object-keyed-by-swipe format if needed
+    if (Array.isArray(lastMsg.extra.rpgProcessedTags)) {
+        lastMsg.extra.rpgProcessedTags = { [swipeId]: lastMsg.extra.rpgProcessedTags };
+    } else if (!lastMsg.extra.rpgProcessedTags) {
+        lastMsg.extra.rpgProcessedTags = {};
+    }
+    lastMsg.extra.rpgRollbackData = lastMsg.extra.rpgRollbackData || {};
+
+    // Detect swipe change and perform rollback
+    if (lastMsg.extra.rpgActiveSwipe !== undefined && lastMsg.extra.rpgActiveSwipe !== swipeId) {
+        const prevSwipeId = lastMsg.extra.rpgActiveSwipe;
+        console.log(`[RPG Tracker] Swipe changed from ${prevSwipeId} to ${swipeId}. Rolling back previous allocations.`);
+        
+        if (lastMsg.extra.rpgRollbackData[prevSwipeId]) {
+            for (const rb of lastMsg.extra.rpgRollbackData[prevSwipeId]) {
+                // Reverse the exact delta that was successfully applied
+                if (settings.npcRelationshipValues && settings.npcRelationshipValues[rb.npcId]) {
+                    const current = settings.npcRelationshipValues[rb.npcId][rb.field] ?? 0;
+                    settings.npcRelationshipValues[rb.npcId][rb.field] = Math.max(-100, Math.min(100, current - rb.actualAppliedDelta));
+                }
+                
+                // Remove the exact log entry
+                if (settings.npcRelationshipLog && Array.isArray(settings.npcRelationshipLog[rb.npcId])) {
+                    settings.npcRelationshipLog[rb.npcId] = settings.npcRelationshipLog[rb.npcId].filter(l => l.timestamp !== rb.logTimestamp);
+                }
+                console.log(`[RPG Tracker] Rolled back ${rb.field} delta (${rb.actualAppliedDelta}) for ${rb.npcId}`);
+            }
+            anyChanged = true;
+        }
+
+        // We are entering a new swipe. Clear its tracking data so it gets evaluated fresh.
+        lastMsg.extra.rpgProcessedTags[swipeId] = [];
+        lastMsg.extra.rpgRollbackData[swipeId] = [];
+    }
+
+    lastMsg.extra.rpgActiveSwipe = swipeId;
+    lastMsg.extra.rpgProcessedTags[swipeId] = lastMsg.extra.rpgProcessedTags[swipeId] || [];
+    lastMsg.extra.rpgRollbackData[swipeId] = lastMsg.extra.rpgRollbackData[swipeId] || [];
+
+    // --- 2. EARLY RETURNS (After Rollback) ---
     if (!/\[REL:/i.test(lastMsg.mes)) {
         console.log('[RPG Tracker] Aborting: lastMsg.mes does not contain [REL:');
+        if (anyChanged) triggerUIUpdate();
         return;
     }
 
@@ -861,20 +916,6 @@ export async function processRelationshipTags(msgIndex) {
     const matches = [];
     let match;
     
-    // Ensure the message has an extra metadata dictionary for tracking processed tags
-    lastMsg.extra = lastMsg.extra || {};
-    // Use swipe_id to prevent previous swipes from falsely deduplicating the current swipe
-    const swipeId = lastMsg.swipe_id ?? 0;
-    
-    // Convert old array format to object-keyed-by-swipe format if needed
-    if (Array.isArray(lastMsg.extra.rpgProcessedTags)) {
-        lastMsg.extra.rpgProcessedTags = { [swipeId]: lastMsg.extra.rpgProcessedTags };
-    } else if (!lastMsg.extra.rpgProcessedTags) {
-        lastMsg.extra.rpgProcessedTags = {};
-    }
-    
-    lastMsg.extra.rpgProcessedTags[swipeId] = lastMsg.extra.rpgProcessedTags[swipeId] || [];
-
     while ((match = REL_RE.exec(lastMsg.mes)) !== null) {
         const matchStr = match[0];
         
@@ -899,6 +940,7 @@ export async function processRelationshipTags(msgIndex) {
 
     if (matches.length === 0) {
         console.log('[RPG Tracker] Aborting: matches.length === 0 after parsing');
+        if (anyChanged) triggerUIUpdate();
         return;
     }
 
@@ -943,19 +985,31 @@ export async function processRelationshipTags(msgIndex) {
             if (!settings.npcRelationshipValues[resolved.id]) settings.npcRelationshipValues[resolved.id] = { friendship: 0, affection: 0 };
             
             const prev = settings.npcRelationshipValues[resolved.id][m.field] ?? 0;
-            settings.npcRelationshipValues[resolved.id][m.field] = Math.max(-100, Math.min(100, prev + m.delta));
+            const newVal = Math.max(-100, Math.min(100, prev + m.delta));
+            const actualAppliedDelta = newVal - prev;
+            settings.npcRelationshipValues[resolved.id][m.field] = newVal;
 
             if (!settings.npcRelationshipLog) settings.npcRelationshipLog = {};
             // Strict array check to prevent crashes from corrupted legacy data
             if (!Array.isArray(settings.npcRelationshipLog[resolved.id])) settings.npcRelationshipLog[resolved.id] = [];
-            settings.npcRelationshipLog[resolved.id].unshift({ timestamp: Date.now(), field: m.field, delta: m.delta, newValue: settings.npcRelationshipValues[resolved.id][m.field], source: 'ai' });
+            
+            const logTimestamp = Date.now();
+            settings.npcRelationshipLog[resolved.id].unshift({ timestamp: logTimestamp, field: m.field, delta: m.delta, newValue: newVal, source: 'ai' });
             
             const sign = m.delta > 0 ? '+' : '';
             const icon = m.field === 'friendship' ? '🤝' : '💗';
             const label = m.field === 'friendship' ? 'Friendship' : 'Affection';
             // @ts-ignore
             toastr.info(`${icon} ${m.name}: ${sign}${m.delta} ${label}`, 'Relationship', { timeOut: 3500, positionClass: 'toast-bottom-right' });
-            console.log(`[RPG Tracker] Applied relationship delta: ${m.name} | ${m.field} | ${m.delta}`);
+            console.log(`[RPG Tracker] Applied relationship delta: ${m.name} | ${m.field} | ${m.delta} (Actual: ${actualAppliedDelta})`);
+
+            // Save rollback data for future swipes
+            lastMsg.extra.rpgRollbackData[swipeId].push({
+                npcId: resolved.id,
+                field: m.field,
+                actualAppliedDelta: actualAppliedDelta,
+                logTimestamp: logTimestamp
+            });
 
             // Mark this specific tag string as processed in the message metadata for THIS swipe
             lastMsg.extra.rpgProcessedTags[swipeId].push(m.rawStr);
@@ -968,17 +1022,7 @@ export async function processRelationshipTags(msgIndex) {
     }
 
     if (anyChanged) {
-        // Persist the message metadata so it survives reloads
-        if (typeof ctx.saveChatDebounced === 'function') ctx.saveChatDebounced();
-
-        ctx.saveSettingsDebounced?.();
-        if (typeof globalThis._rpgRenderRouterUI === 'function') globalThis._rpgRenderRouterUI();
-        
-        // Lightweight surgical DOM update: patch only the bar fill + value text
-        // without reloading the entire manifest (which is very slow on large installs).
-        refreshRelationshipBarsDOM(settings);
-        
-        document.dispatchEvent(new CustomEvent('rt_lore_agent_updated'));
+        triggerUIUpdate();
     }
 }
 

--- a/portraits.js
+++ b/portraits.js
@@ -316,20 +316,22 @@ Rules:
 
     const userPrompt = contextParts.join('\n\n---\n\n');
 
-    const portraitSettings = {
-        connectionSource: s.portraitConnectionSource ?? 'default',
-        connectionProfileId: s.portraitConnectionProfileId || '',
-        completionPresetId: s.portraitCompletionPresetId || '',
-        ollamaUrl: s.portraitOllamaUrl || 'http://localhost:11434',
-        ollamaModel: s.portraitOllamaModel || '',
-        openaiUrl: s.portraitOpenaiUrl || '',
-        openaiKey: s.portraitOpenaiKey || '',
-        openaiModel: s.portraitOpenaiModel || '',
+    // NPC lorebook portrait prompts use the Lorebook Agent AI, not the portrait AI,
+    // since the lorebook agent has the relevant NPC context and connection configured.
+    const lorebookAiSettings = {
+        connectionSource: s.routerConnectionSource ?? 'default',
+        connectionProfileId: s.routerConnectionProfileId || '',
+        completionPresetId: s.routerCompletionPresetId || '',
+        ollamaUrl: s.routerOllamaUrl || 'http://localhost:11434',
+        ollamaModel: s.routerOllamaModel || '',
+        openaiUrl: s.routerOpenaiUrl || '',
+        openaiKey: s.routerOpenaiKey || '',
+        openaiModel: s.routerOpenaiModel || '',
         maxTokens: s.maxTokens,
         debugMode: s.debugMode,
     };
 
-    const result = await sendStateRequest(portraitSettings, systemPrompt, userPrompt);
+    const result = await sendStateRequest(lorebookAiSettings, systemPrompt, userPrompt);
     return (result || '').trim();
 }
 

--- a/portraits.js
+++ b/portraits.js
@@ -658,8 +658,8 @@ export async function generateWithPollinations(prompt, entityName, localApply, r
             // Wait for generation to finish, then scale and apply directly
             try {
                 const dataUrl = await genPromise;
-                const scaled = await scaleImageTo512Square(dataUrl);
-                localApply(scaled);
+                const finalUrl = dataUrl.startsWith('data:') ? await scaleImageTo512Square(dataUrl) : dataUrl;
+                localApply(finalUrl);
                 if (typeof refresh === 'function') refresh();
                 toastr['success'](`Portrait applied for ${entityName}!`, 'RPG Tracker');
             } catch (err) {
@@ -748,8 +748,8 @@ export async function generateWithNativeExtension(prompt, entityName, localApply
             // Wait for generation to finish, then scale and apply
             try {
                 const imageUrl = await genPromise;
-                const scaled = await scaleImageTo512Square(imageUrl);
-                localApply(scaled);
+                const finalUrl = imageUrl.startsWith('data:') ? await scaleImageTo512Square(imageUrl) : imageUrl;
+                localApply(finalUrl);
                 if (typeof refresh === 'function') refresh();
                 toastr['success'](`Portrait applied for ${entityName}!`, 'RPG Tracker');
             } catch (err) {

--- a/router.js
+++ b/router.js
@@ -255,12 +255,32 @@ export async function runRouterPass(narrativeOutput, manualPrompt = null, custom
         function updateActiveEntries() {
             activeEntriesFull = [];
             newlyTriggeredFull = [];
+            const relValues = settings.npcRelationshipValues || {};
             for (const [name, book] of Object.entries(archiveBooks)) {
                 for (const [uid, entry] of Object.entries(book.entries)) {
                     const fullId = `${name}::${uid}`;
                     if (settings.activeRouterKeys?.includes(fullId)) {
                         const label = entry.comment || entry.key?.[0] || fullId;
                         let block = `### [ACTIVE] ${label}\nID: ${fullId}\nContent: ${entry.content}`;
+                        // Append cap-constraint hints for NPC relationship values.
+                        // Totals are intentionally hidden so the agent awards deltas from
+                        // a consistent baseline, uncorrupted by the existing pool size.
+                        // Only inject a hint when a value is near the cap (within 15 points)
+                        // so the agent knows further movement in that direction is futile.
+                        const rel = relValues[fullId];
+                        if (rel !== undefined) {
+                            const fVal = rel.friendship ?? 0;
+                            const aVal = rel.affection  ?? 0;
+                            // Always inject current totals so the agent can calibrate delta magnitude
+                            block += `\n[Current Relations: Friendship ${fVal >= 0 ? '+' : ''}${fVal}, Affection ${aVal >= 0 ? '+' : ''}${aVal}]`;
+                            // Cap-constraint hints (only when at limit)
+                            const hints = [];
+                            if (fVal >= 100)  hints.push('Friendship is at maximum — do not award further positive increments');
+                            if (fVal <= -100) hints.push('Friendship is at minimum — do not award further negative increments');
+                            if (aVal >= 100)  hints.push('Affection is at maximum — do not award further positive increments');
+                            if (aVal <= -100) hints.push('Affection is at minimum — do not award further negative increments');
+                            if (hints.length > 0) block += `\n⚠ Relationship constraint: ${hints.join('; ')}.`;
+                        }
                         if (triggeredSet.has(fullId)) {
                             newlyTriggeredFull.push(block);
                         } else {
@@ -792,6 +812,12 @@ ${modularPrompt}
 4. **RECALL**: To read or update an archive entry, use [[ACTIVATE: Name]]. Its full content becomes visible next turn.
 5. **LIMIT**: You are limited to **${settings.routerMaxActivations || 8} active entries**. Nothing is archived automatically. If you exceed this limit you will see a **BUDGET VIOLATION** line and you MUST use [[DEACTIVATE: Name]] on the least relevant active entries to return within budget before this pass ends.
 
+## NPC RELATIONSHIP DELTAS
+If an NPC's relationship with the player changes meaningfully based on events, output:
+  [[REL: Book::UID | Friendship | +15]]   (use the exact UID from the active memory block)
+  [[REL: Book::UID | Affection | -10]]
+Output only the delta — do NOT rewrite bar values in the entry text. Base your judgment on the NPC's personality, values, and temperament as described in their entry, inferring how they would realistically react.
+
 ## NPC APPEARANCE UPDATES
 If an NPC's physical appearance changes significantly (major injury, permanent outfit change, etc.), output:
   [[UPDATE_APPEARANCE: Book::UID | New appearance text here]]
@@ -963,6 +989,19 @@ Thought: I see a new NPC named Barnaby in Khelt's Rust-Lantern District. I will 
                                         required: ['id']
                                     }
                                 },
+                                rel: {
+                                    type: 'array',
+                                    description: 'Apply relationship delta(s) to NPC(s). Base relationship changes on the NPC\'s personality, values, and temperament as described in their entry, inferring what they would realistically appreciate or resent. Do NOT include the current total — output only the signed integer delta.',
+                                    items: {
+                                        type: 'object',
+                                        properties: {
+                                            id:    { type: 'string', description: 'Book::UID of the NPC entry.' },
+                                            field: { type: 'string', enum: ['friendship', 'affection'], description: 'Which relationship axis to update.' },
+                                            delta: { type: 'integer', description: 'Signed integer delta (e.g. 15 or -20). Range: -100 to 100.' }
+                                        },
+                                        required: ['id', 'field', 'delta']
+                                    }
+                                },
                                 appearance: {
                                     type: 'array',
                                     description: 'Surgically update the Appearance field inside an NPC\'s [CORE] block. Only use when the NPC\'s physical appearance changes significantly.',
@@ -1036,11 +1075,12 @@ Available actions:
 - grep_lore({"query": "..."}) ? search lorebooks for entries matching a keyword
 - inspect_book({"book_name": "..."}) ? list UIDs in a lorebook
 - read_entry({"uid": "Book::0"}) ? read full content of an entry
-- commit({"record": [...], "update": [...], "rename": [...], "activate": [...], "deactivate": [...], "delete_ids": [...], "appearance": [...]}) ? write all changes and finish
+- commit({"record": [...], "update": [...], "rename": [...], "activate": [...], "deactivate": [...], "delete_ids": [...], "rel": [...], "appearance": [...]}) ? write all changes and finish
 
 commit record items: {"label": "Name only (NO tag prefix)", "keys": ["kw1","kw2"], "content": "...", "category": "NPC|LOC|FAC|QUEST|EVENT"}
 commit update items: {"id": "Book::UID", "content": "new text to append"}
 commit rename items: {"id": "Book::UID", "label": "New Name (optional)", "keys": ["kw1","kw2"] (optional, max 6)}
+commit rel items: {"id": "Book::UID", "field": "friendship"|"affection", "delta": ±N} — output only the delta, not the total
 commit appearance items: {"id": "Book::UID", "content": "new appearance text"} — surgically updates the Appearance field inside [CORE]}
 
 ## EXAMPLE
@@ -1666,7 +1706,32 @@ async function applyAction(action, allBooks = {}, currentTime = '', breadcrumb =
         document.dispatchEvent(new CustomEvent('rt_lore_agent_updated'));
     }
 
-    // 5. Appearance updates — surgical replacement of the Appearance field inside [CORE]
+    // 5. Relationship deltas
+    for (const item of (action.rel || [])) {
+        const { id, field, delta } = item;
+        if (!id || !field || typeof delta !== 'number') {
+            errors.push(`Invalid rel item: ${JSON.stringify(item)}`);
+            continue;
+        }
+        const f = field.toLowerCase();
+        if (f !== 'friendship' && f !== 'affection') {
+            errors.push(`Unknown relationship field "${field}" for ${id}`);
+            continue;
+        }
+        if (!settings.npcRelationshipValues) settings.npcRelationshipValues = {};
+        if (!settings.npcRelationshipValues[id]) settings.npcRelationshipValues[id] = { friendship: 0, affection: 0 };
+        const current = settings.npcRelationshipValues[id][f] ?? 0;
+        const newValue = Math.max(-100, Math.min(100, current + delta));
+        settings.npcRelationshipValues[id][f] = newValue;
+        // Append to relationship change log (capped at 50 entries per NPC)
+        if (!settings.npcRelationshipLog) settings.npcRelationshipLog = {};
+        if (!settings.npcRelationshipLog[id]) settings.npcRelationshipLog[id] = [];
+        settings.npcRelationshipLog[id].unshift({ timestamp: Date.now(), field: f, delta, newValue, source: 'agent' });
+        if (settings.npcRelationshipLog[id].length > 50) settings.npcRelationshipLog[id].length = 50;
+        changed = true;
+    }
+
+    // 6. Appearance updates — surgical replacement of the Appearance field inside [CORE]
     for (const item of (action.appearance || [])) {
         const { id, content: newAppearance } = item;
         if (!id || !newAppearance) {
@@ -1855,7 +1920,7 @@ export async function reapplyRouterPass(prePassSnapshot, postPassState) {
  * Parses basic narrative tags [[TAG: ...]]
  */
 function parseBasicTags(text, archiveBooks) {
-    const action = { record: [], update: [], activate: [], deactivate: [], delete_ids: [], rewrite: [], consolidate: [], appearance: [] };
+    const action = { record: [], update: [], activate: [], deactivate: [], delete_ids: [], rewrite: [], consolidate: [], rel: [], appearance: [] };
     const settings = getSettings();
 
     // REWRITE tag parser
@@ -1877,6 +1942,17 @@ function parseBasicTags(text, archiveBooks) {
         action.consolidate.push({ targets, survivor, content });
     }
 
+    // REL tag parser: [[REL: Book::UID | Friendship | +15]]
+    const relRegex = /\[\[REL:\s*([^|]+)\|\s*(friendship|affection)\s*\|\s*([+-]?\d+)\s*\]\]/gi;
+    let rm;
+    while ((rm = relRegex.exec(text)) !== null) {
+        const id    = rm[1].trim();
+        const field = rm[2].trim().toLowerCase();
+        const delta = parseInt(rm[3], 10);
+        if (id && field && !isNaN(delta)) {
+            action.rel.push({ id, field, delta });
+        }
+    }
 
     // UPDATE_APPEARANCE tag parser: [[UPDATE_APPEARANCE: Book::UID | new appearance text]]
     const appearRegex = /\[\[UPDATE_APPEARANCE:\s*([^|]+)\|([\s\S]*?)\]\]/gi;
@@ -1921,7 +1997,7 @@ function parseBasicTags(text, archiveBooks) {
 
     while ((match = tagRegex.exec(text)) !== null) {
         const tagName = match[1].toUpperCase();
-        if (tagName === 'REWRITE' || tagName === 'CONSOLIDATE' || tagName === 'UPDATE_APPEARANCE') continue; // Collision protection
+        if (tagName === 'REWRITE' || tagName === 'CONSOLIDATE' || tagName === 'REL' || tagName === 'UPDATE_APPEARANCE') continue; // Collision protection
 
         const inner = match[2];
         const parts = inner.split('|').map(p => p.trim());

--- a/settings.html
+++ b/settings.html
@@ -519,7 +519,11 @@
                                     <label style="font-size: 11px; opacity: 0.7;">Minor NPC Section Word Target</label>
                                     <input id="rpg_tracker_npc_minor_words" type="text" inputmode="numeric" pattern="[0-9]*" class="text_pole" value="15" title="Shopkeepers, guards, one-off encounters. Default: 15 words per section of [CORE]" />
                                     
-
+                                    <label class="checkbox_label">
+                                        <input id="rpg_tracker_npc_rel_bars" type="checkbox" />
+                                        <span>Relationship Bars</span>
+                                        <i class="fa-solid fa-circle-question interactable" style="font-size: 0.85em; opacity: 0.7; margin-left: 4px;" title="Shows Friendship/Affection tracking bars on NPC cards and popups. Also adds relationship fields to the AI instruction."></i>
+                                    </label>
 
                                     <label class="checkbox_label">
                                         <input id="rpg_tracker_npc_card_import" type="checkbox" />

--- a/state-manager.js
+++ b/state-manager.js
@@ -39,40 +39,7 @@ After the [/CORE] block, append timestamped narrative updates as usual ([Day X, 
 ## APPEARANCE UPDATES
 If the NPC's physical appearance changes significantly (major injury, permanent outfit change, etc.), output:
   [[UPDATE_APPEARANCE: Book::UID | New appearance text]]
-This surgically replaces only the Appearance field inside [CORE]. Do NOT write appearance changes as event/update entries.
-
-## RELATIONSHIP DELTAS
-If the NPC's relationship with the player meaningfully changes based on what happened, output:
-  [[REL: Book::UID | Friendship | +N]] or [[REL: Book::UID | Friendship | -N]]
-  [[REL: Book::UID | Affection | +N]] or [[REL: Book::UID | Affection | -N]]
-Output only the delta — do NOT write or track the relationship total. The current total is intentionally hidden from you so your judgment stays anchored to the quality of the interaction, not the existing pool.
-
-<REL_JUDGMENT>
-Base your judgment on the NPC's personality from their [CORE] block. What they would realistically appreciate, tolerate, or resent depends on their temperament, values, culture, and personal history.
-
-SITUATIONS THAT WARRANT ALLOCATION (non-exhaustive — adapt to ALL contexts):
-• Direct social acts: compliments, insults, gifts, threats, apologies (+/-1 to 5)
-• Bonding moments: sharing a meal, campfire talks, traveling together, discussing shared interests (+1 to 4 friendship)
-• Shared adversity: surviving combat together, escaping danger, enduring hardship side by side (+3 to 8 friendship)
-• Quest completion: finishing a task that matters to the NPC, fulfilling a promise (+3 to 10 friendship)
-• Betrayal or broken trust: lying, breaking a promise, abandoning them in danger (-5 to -15 friendship)
-• Acts of sacrifice: risking your life for them, giving up something valuable for their sake (+8 to 15 friendship or affection depending on context)
-• Romantic gestures: flirtation, a meaningful gift, a protective act, physical intimacy (+1 to 8 affection)
-• Rejection or disrespect of their values/culture/loved ones (-3 to -10 friendship, sometimes also affection)
-• Being ignored, forgotten, or treated as unimportant (-1 to -4 friendship)
-• Prolonged positive interaction over an extended scene (+2 to 4 of either or both)
-
-MAGNITUDE GUIDELINES:
-• A stoic warrior might shift +1 where a warm innkeeper shifts +3 for the same compliment
-• Personality matters more than the act itself — gauge against WHO the NPC is
-• Typical range: 1-5 for minor moments, 5-15 for major events, 15+ only for life-altering moments
-• A constraint warning will appear if a value hits its hard limit (100 or -100); do not award further in the capped direction
-
-DO NOT ALLOCATE when:
-• The interaction is purely transactional with no emotional weight (buying supplies, asking for directions)
-• The NPC is not present in the scene
-• Nothing meaningful happened between the protagonist and the specific NPC
-</REL_JUDGMENT>`;
+This surgically replaces only the Appearance field inside [CORE]. Do NOT write appearance changes as event/update entries.`;
 
     instruction += `\n\nBe concise and functional — every word should serve gameplay or characterization. Avoid adjective dumps and purple prose.
 

--- a/state-manager.js
+++ b/state-manager.js
@@ -45,7 +45,34 @@ This surgically replaces only the Appearance field inside [CORE]. Do NOT write a
 If the NPC's relationship with the player meaningfully changes based on what happened, output:
   [[REL: Book::UID | Friendship | +N]] or [[REL: Book::UID | Friendship | -N]]
   [[REL: Book::UID | Affection | +N]] or [[REL: Book::UID | Affection | -N]]
-Output only the delta — do NOT write or track the relationship total. The current total is intentionally hidden from you so your judgment stays anchored to the quality of the interaction, not the existing pool. Base your judgment on the personality of the NPC in question (e.g., from their [CORE] block), inferring what they would realistically appreciate, tolerate, or resent given their temperament, values, and traits. A constraint warning will appear in the entry only if a value has reached its hard limit (100 or -100); in that case, do not award further increments in the capped direction. Use your judgment on magnitude (typical range: ±5 to ±25 per turn).`;
+Output only the delta — do NOT write or track the relationship total. The current total is intentionally hidden from you so your judgment stays anchored to the quality of the interaction, not the existing pool.
+
+<REL_JUDGMENT>
+Base your judgment on the NPC's personality from their [CORE] block. What they would realistically appreciate, tolerate, or resent depends on their temperament, values, culture, and personal history.
+
+SITUATIONS THAT WARRANT ALLOCATION (non-exhaustive — adapt to ALL contexts):
+• Direct social acts: compliments, insults, gifts, threats, apologies (+/-1 to 5)
+• Bonding moments: sharing a meal, campfire talks, traveling together, discussing shared interests (+1 to 4 friendship)
+• Shared adversity: surviving combat together, escaping danger, enduring hardship side by side (+3 to 8 friendship)
+• Quest completion: finishing a task that matters to the NPC, fulfilling a promise (+3 to 10 friendship)
+• Betrayal or broken trust: lying, breaking a promise, abandoning them in danger (-5 to -15 friendship)
+• Acts of sacrifice: risking your life for them, giving up something valuable for their sake (+8 to 15 friendship or affection depending on context)
+• Romantic gestures: flirtation, a meaningful gift, a protective act, physical intimacy (+1 to 8 affection)
+• Rejection or disrespect of their values/culture/loved ones (-3 to -10 friendship, sometimes also affection)
+• Being ignored, forgotten, or treated as unimportant (-1 to -4 friendship)
+• Prolonged positive interaction over an extended scene (+2 to 4 of either or both)
+
+MAGNITUDE GUIDELINES:
+• A stoic warrior might shift +1 where a warm innkeeper shifts +3 for the same compliment
+• Personality matters more than the act itself — gauge against WHO the NPC is
+• Typical range: 1-5 for minor moments, 5-15 for major events, 15+ only for life-altering moments
+• A constraint warning will appear if a value hits its hard limit (100 or -100); do not award further in the capped direction
+
+DO NOT ALLOCATE when:
+• The interaction is purely transactional with no emotional weight (buying supplies, asking for directions)
+• The NPC is not present in the scene
+• Nothing meaningful happened between the protagonist and the specific NPC
+</REL_JUDGMENT>`;
 
     instruction += `\n\nBe concise and functional — every word should serve gameplay or characterization. Avoid adjective dumps and purple prose.
 
@@ -682,6 +709,13 @@ Example: [[FAC: Iron Syndicate | ...]]  NOT  [[FAC: Khelt :: Iron Syndicate | ..
         s.settingsVersion = '3.16.13';
     }
 
+    // Expand NPC relationship delta guidance with situational examples (v3.16.14)
+    if (!s.settingsVersion || s.settingsVersion < '3.16.14') {
+        if (s.routerModules?.npc) {
+            s.routerModules.npc.instruction = buildNpcInstruction(s.npcMajorWords, s.npcMinorWords);
+        }
+        s.settingsVersion = '3.16.14';
+    }
 
     // ── MIGRATION: Update system prompts with keywords instructions (v3.2.3+) ──────
     if (s.routerSystemPromptTemplate && !s.routerSystemPromptTemplate.includes('IMPORTANT FOR KEYWORDS')) {

--- a/state-manager.js
+++ b/state-manager.js
@@ -629,11 +629,13 @@ Example: [[FAC: Iron Syndicate | ...]]  NOT  [[FAC: Khelt :: Iron Syndicate | ..
 
     // Migrate NPC limits from total words to per-section word targets (v3.13.0)
     if (!s.settingsVersion || s.settingsVersion < '3.13.0') {
-        // Convert old total word limits (90/60) to reasonable per-section defaults (25/15)
-        if (s.npcMajorWords === 90 || s.npcMajorWords > 100) {
+        // Convert old total word limits (90/60) to reasonable per-section defaults (25/15).
+        // Only reset clearly legacy token-era values — NOT arbitrary high word counts.
+        // Threshold raised to 1000 so users can freely set values like 200, 300, 400+.
+        if (s.npcMajorWords === 90 || s.npcMajorWords > 1000) {
             s.npcMajorWords = 25;
         }
-        if (s.npcMinorWords === 60 || s.npcMinorWords > 100) {
+        if (s.npcMinorWords === 60 || s.npcMinorWords > 1000) {
             s.npcMinorWords = 15;
         }
         // Rebuild instruction with new length target wording

--- a/state-manager.js
+++ b/state-manager.js
@@ -39,7 +39,13 @@ After the [/CORE] block, append timestamped narrative updates as usual ([Day X, 
 ## APPEARANCE UPDATES
 If the NPC's physical appearance changes significantly (major injury, permanent outfit change, etc.), output:
   [[UPDATE_APPEARANCE: Book::UID | New appearance text]]
-This surgically replaces only the Appearance field inside [CORE]. Do NOT write appearance changes as event/update entries.`;
+This surgically replaces only the Appearance field inside [CORE]. Do NOT write appearance changes as event/update entries.
+
+## RELATIONSHIP DELTAS
+If the NPC's relationship with the player meaningfully changes based on what happened, output:
+  [[REL: Book::UID | Friendship | +N]] or [[REL: Book::UID | Friendship | -N]]
+  [[REL: Book::UID | Affection | +N]] or [[REL: Book::UID | Affection | -N]]
+Output only the delta — do NOT write or track the relationship total. The current total is intentionally hidden from you so your judgment stays anchored to the quality of the interaction, not the existing pool. Base your judgment on the personality of the NPC in question (e.g., from their [CORE] block), inferring what they would realistically appreciate, tolerate, or resent given their temperament, values, and traits. A constraint warning will appear in the entry only if a value has reached its hard limit (100 or -100); in that case, do not award further increments in the capped direction. Use your judgment on magnitude (typical range: ±5 to ±25 per turn).`;
 
     instruction += `\n\nBe concise and functional — every word should serve gameplay or characterization. Avoid adjective dumps and purple prose.
 
@@ -107,6 +113,9 @@ export function getSettings() {
         showTotalInventoryValue: true,
         npcMajorWords: 25,
         npcMinorWords: 15,
+        npcRelationshipBars: false,
+        npcRelationshipValues: {},
+        npcRelationshipLog: {},      // { [fullId]: [{timestamp,field,delta,newValue,source}] } — capped 50/NPC
         experimentalNpcImport: true,
         barColors: {},
         modulePageSizes: {},
@@ -576,6 +585,7 @@ Example: [[FAC: Iron Syndicate | ...]]  NOT  [[FAC: Khelt :: Iron Syndicate | ..
         // Ensure NPC settings exist with defaults
         if (s.npcMajorTokens === undefined) s.npcMajorTokens = 125;
         if (s.npcMinorTokens === undefined) s.npcMinorTokens = 100;
+        if (s.npcRelationshipBars === undefined) s.npcRelationshipBars = false;
         // Rebuild instruction from current settings
         if (s.routerModules?.npc) {
             s.routerModules.npc.instruction = buildNpcInstruction(s.npcMajorTokens, s.npcMinorTokens);
@@ -585,6 +595,8 @@ Example: [[FAC: Iron Syndicate | ...]]  NOT  [[FAC: Khelt :: Iron Syndicate | ..
 
     // Migrate NPC system to [CORE] tag, code-owned relationship bars, and delta-based updates (v3.11.0)
     if (!s.settingsVersion || s.settingsVersion < '3.11.0') {
+        // Initialize relationship value store
+        if (!s.npcRelationshipValues) s.npcRelationshipValues = {};
         // Force-rebuild NPC instruction to new format
         if (s.routerModules?.npc) {
             s.routerModules.npc.instruction = buildNpcInstruction(

--- a/style.css
+++ b/style.css
@@ -2714,6 +2714,79 @@
     border: 1px solid rgba(255, 255, 255, 0.1);
 }
 
+/* ── NPC Relationship Bars ── */
+.rt-npc-bars {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    margin-top: 3px;
+    width: 100%;
+}
+.rt-npc-bar-row {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 8px;
+    color: var(--rt-text-muted);
+}
+.rt-npc-bar-icon {
+    flex-shrink: 0;
+    width: 12px;
+    text-align: center;
+    font-size: 9px;
+}
+.rt-npc-bar-track {
+    flex: 1;
+    height: 6px;
+    background: rgba(255, 255, 255, 0.06);
+    border-radius: 3px;
+    position: relative;
+    overflow: hidden;
+}
+.rt-npc-bar-center-marker {
+    position: absolute;
+    left: 50%;
+    top: 0;
+    bottom: 0;
+    width: 1px;
+    background: rgba(255, 255, 255, 0.15);
+    z-index: 1;
+}
+.rt-npc-bar-fill {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    border-radius: 3px;
+    transition: width 0.3s ease, left 0.3s ease, background 0.3s ease;
+}
+/* Positive fill: grows from center to right */
+.rt-npc-bar-fill.positive {
+    left: 50%;
+}
+/* Negative fill: grows from center to left */
+.rt-npc-bar-fill.negative {
+    right: 50%;
+}
+.rt-npc-bar-fill.friendship-pos { background: linear-gradient(90deg, #4ade8088, #4ade80); }
+.rt-npc-bar-fill.friendship-neg { background: linear-gradient(270deg, #ef444488, #ef4444); }
+.rt-npc-bar-fill.affection-pos  { background: linear-gradient(90deg, #f472b688, #f472b6); }
+.rt-npc-bar-fill.affection-neg  { background: linear-gradient(270deg, #a855f788, #a855f7); }
+
+.rt-npc-bar-value {
+    flex-shrink: 0;
+    width: 26px;
+    text-align: right;
+    font-family: var(--rt-font-mono);
+    font-size: 8px;
+    font-weight: bold;
+    line-height: 1;
+}
+.rt-npc-bar-value.val-positive { color: #4ade80; }
+.rt-npc-bar-value.val-negative { color: #ef4444; }
+.rt-npc-bar-value.val-zero     { color: var(--rt-text-muted); }
+.rt-npc-bar-value.val-affection-positive { color: #f472b6; }
+.rt-npc-bar-value.val-affection-negative { color: #a855f7; }
+
 /* ── NPC Card Actions ── */
 .rt-npc-actions {
     display: flex;

--- a/sysprompt.txt
+++ b/sysprompt.txt
@@ -246,6 +246,27 @@ RELATIONSHIP TRACKING — only active when [NPC_RELATIONS] appears in context.
 WHEN TO EMIT:
 Be selective and natural about it. Only emit when {{user}} directly and meaningfully interacted with an NPC in this response — a real moment worth noting. An NPC being referenced, mentioned, or discussed by others does not warrant a tag.
 
+Relationship shifts are NOT limited to obvious social acts. Consider ALL of the following (non-exhaustive — use your judgment for ANY situation):
+• Direct compliments, insults, gifts, threats, apologies
+• Sharing a meal, campfire conversation, bonding over shared interests or memories
+• Surviving danger together, escaping a trap, enduring hardship side by side
+• Completing a quest that matters to the NPC, fulfilling a promise made to them
+• Betrayal, breaking a promise, abandoning or failing to protect them
+• Saving their life or a loved one's life
+• Flirtatious banter — received well OR poorly depending on the NPC's current feelings
+• A meaningful personal confession, a vulnerable moment shared
+• A romantic gesture — a dance, a gift with personal significance, a protective act in romantic context
+• Spending extended quality time together with positive interactions
+• Disrespecting their values, culture, religion, or loved ones
+• Ignoring them, forgetting something important to them, treating them as unimportant
+
+MAGNITUDE MUST reflect the NPC's personality. A stoic warrior might shift +1 where a warm innkeeper shifts +3 for the same compliment. Personality matters more than the act itself — gauge against WHO the NPC is, their temperament, values, and what they care about.
+
+DO NOT EMIT when:
+• The interaction is purely transactional with no emotional weight (buying supplies, asking for directions)
+• The NPC is not present or participating in the scene
+• Nothing meaningful happened between {{user}} and the specific NPC this turn
+
 INLINE ANNOTATION (visible — place immediately after the triggering moment):
 *(Friendship: Marcus +10 — saved his life in the alley)*
 *(Affection: Elena +2 — she seemed touched by the compliment)*
@@ -255,28 +276,32 @@ MACHINE TAGS (stripped before display — place ALL at the very end of the respo
   FirstName = NPC's first name only | field = friendship or affection | delta = signed integer
 
 FRIENDSHIP EXAMPLES (guides, not hard rules):
-+1/+2 ... Small warmth, casual kindness, shared laugh
-+2/+5 ... Genuine compliment, meaningful help with a problem
-+5/+10 .. Surviving danger together, real heartfelt conversation
-+10/+15 . Protecting or defending them, significant act of loyalty
-+15/+25 . Saving their life
++1/+2 ... Small warmth, casual kindness, shared laugh, pleasant campfire talk
++2/+5 ... Genuine compliment, meaningful help with a problem, bonding over shared interests
++5/+10 .. Surviving danger together, real heartfelt conversation, completing a shared goal
++10/+15 . Protecting or defending them, significant act of loyalty, keeping a difficult promise
++15/+25 . Saving their life, major self-sacrifice for their sake
 +25/+30 . Blood oath, brotherhood/sisterhood pact
--3/-5 ... Minor let-down, small broken promise
--5/-10 .. Insult, dismissal, belittling
+-1/-3 ... Being dismissive, forgetting something they told you, mild rudeness
+-3/-5 ... Minor let-down, small broken promise, ignoring them in a group
+-5/-10 .. Insult, dismissal, belittling, disrespecting their beliefs
 -10/-20 . Public humiliation, badmouthing them (if overheard)
--20/-30 . Abandoning them in danger
+-20/-30 . Abandoning them in danger, breaking a major promise
 -40/-60 . Betraying them to an enemy
 
 AFFECTION EXAMPLES (guides, not hard rules):
-+1 ...... Subtle kind gesture, attentive small detail
++1 ...... Subtle kind gesture, attentive small detail, noticing something about them
 +2/+3 ... Sincere compliment on appearance, wit, or spirit
-+5/+10 .. Sweet gift, emotional gesture, intimate conversation
-+10/+20 . Protective act (romantic context), vulnerable confession
++5/+10 .. Sweet gift, emotional gesture, intimate conversation, shared vulnerability
++10/+20 . Protective act (romantic context), vulnerable confession of feelings
 +20/+30 . Romantic proposal (if receptive)
+-1/-2 ... Awkward or tone-deaf comment, mild social blunder
 -2/-3 ... Cold or dismissive behavior (per instance)
 -5/-10 .. Public rejection or embarrassment
 -8/-15 .. Flirting with someone else in their presence
 -40/-60 . Romantic betrayal or cheating
+
+Typical range: 1-5 for minor moments, 5-15 for major events. Only use 15+ for life-altering moments.
 
 EXAMPLE — end of a response where {{user}} complimented Elena:
 *(Affection: Elena +2 — she seemed genuinely moved by the words)*

--- a/sysprompt.txt
+++ b/sysprompt.txt
@@ -238,6 +238,52 @@ Status: Condition
 - Short Rest interruption: also active, but the DC should be easier, generally lower than DC 8 unless the area is extremely hostile and dangerous.
 </resting>
 
+<relationship_tracking>
+RELATIONSHIP TRACKING — only active when [NPC_RELATIONS] appears in context.
+
+[NPC_RELATIONS] at the top of each turn shows current standings with active NPCs. Scale: -100 (deep hostility) to +100 (deep bond). Friendship = platonic trust. Affection = romantic/emotional warmth.
+
+WHEN TO EMIT:
+Be selective and natural about it. Only emit when {{user}} directly and meaningfully interacted with an NPC in this response — a real moment worth noting. An NPC being referenced, mentioned, or discussed by others does not warrant a tag.
+
+INLINE ANNOTATION (visible — place immediately after the triggering moment):
+*(Friendship: Marcus +10 — saved his life in the alley)*
+*(Affection: Elena +2 — she seemed touched by the compliment)*
+
+MACHINE TAGS (stripped before display — place ALL at the very end of the response, one per line):
+[REL: FirstName | field | delta]
+  FirstName = NPC's first name only | field = friendship or affection | delta = signed integer
+
+FRIENDSHIP EXAMPLES (guides, not hard rules):
++1/+2 ... Small warmth, casual kindness, shared laugh
++2/+5 ... Genuine compliment, meaningful help with a problem
++5/+10 .. Surviving danger together, real heartfelt conversation
++10/+15 . Protecting or defending them, significant act of loyalty
++15/+25 . Saving their life
++25/+30 . Blood oath, brotherhood/sisterhood pact
+-3/-5 ... Minor let-down, small broken promise
+-5/-10 .. Insult, dismissal, belittling
+-10/-20 . Public humiliation, badmouthing them (if overheard)
+-20/-30 . Abandoning them in danger
+-40/-60 . Betraying them to an enemy
+
+AFFECTION EXAMPLES (guides, not hard rules):
++1 ...... Subtle kind gesture, attentive small detail
++2/+3 ... Sincere compliment on appearance, wit, or spirit
++5/+10 .. Sweet gift, emotional gesture, intimate conversation
++10/+20 . Protective act (romantic context), vulnerable confession
++20/+30 . Romantic proposal (if receptive)
+-2/-3 ... Cold or dismissive behavior (per instance)
+-5/-10 .. Public rejection or embarrassment
+-8/-15 .. Flirting with someone else in their presence
+-40/-60 . Romantic betrayal or cheating
+
+EXAMPLE — end of a response where {{user}} complimented Elena:
+*(Affection: Elena +2 — she seemed genuinely moved by the words)*
+
+[REL: Elena | affection | +2]
+</relationship_tracking>
+
 <state_memo>
 - ## TRACKER STATE 0 (Current) is passed on every turn; its mechanical data is absolute law.
 - Ignore any formatting data such as ((PLS)).

--- a/sysprompt.txt
+++ b/sysprompt.txt
@@ -244,28 +244,9 @@ RELATIONSHIP TRACKING — only active when [NPC_RELATIONS] appears in context.
 [NPC_RELATIONS] at the top of each turn shows current standings with active NPCs. Scale: -100 (deep hostility) to +100 (deep bond). Friendship = platonic trust. Affection = romantic/emotional warmth.
 
 WHEN TO EMIT:
-Be selective and natural about it. Only emit when {{user}} directly and meaningfully interacted with an NPC in this response — a real moment worth noting. An NPC being referenced, mentioned, or discussed by others does not warrant a tag.
+Be selective and natural. Only emit when {{user}} directly and meaningfully interacted with an NPC — a real moment worth noting. Magnitude MUST reflect the NPC's personality: a stoic warrior shifts less than a warm innkeeper for the same act.
 
-Relationship shifts are NOT limited to obvious social acts. Consider ALL of the following (non-exhaustive — use your judgment for ANY situation):
-• Direct compliments, insults, gifts, threats, apologies
-• Sharing a meal, campfire conversation, bonding over shared interests or memories
-• Surviving danger together, escaping a trap, enduring hardship side by side
-• Completing a quest that matters to the NPC, fulfilling a promise made to them
-• Betrayal, breaking a promise, abandoning or failing to protect them
-• Saving their life or a loved one's life
-• Flirtatious banter — received well OR poorly depending on the NPC's current feelings
-• A meaningful personal confession, a vulnerable moment shared
-• A romantic gesture — a dance, a gift with personal significance, a protective act in romantic context
-• Spending extended quality time together with positive interactions
-• Disrespecting their values, culture, religion, or loved ones
-• Ignoring them, forgetting something important to them, treating them as unimportant
-
-MAGNITUDE MUST reflect the NPC's personality. A stoic warrior might shift +1 where a warm innkeeper shifts +3 for the same compliment. Personality matters more than the act itself — gauge against WHO the NPC is, their temperament, values, and what they care about.
-
-DO NOT EMIT when:
-• The interaction is purely transactional with no emotional weight (buying supplies, asking for directions)
-• The NPC is not present or participating in the scene
-• Nothing meaningful happened between {{user}} and the specific NPC this turn
+DO NOT EMIT when: the interaction has no emotional weight (buying supplies, directions), the NPC is absent, or nothing meaningful happened between {{user}} and that NPC this turn.
 
 INLINE ANNOTATION (visible — place immediately after the triggering moment):
 *(Friendship: Marcus +10 — saved his life in the alley)*
@@ -275,33 +256,33 @@ MACHINE TAGS (stripped before display — place ALL at the very end of the respo
 [REL: FirstName | field | delta]
   FirstName = NPC's first name only | field = friendship or affection | delta = signed integer
 
-FRIENDSHIP EXAMPLES (guides, not hard rules):
-+1/+2 ... Small warmth, casual kindness, shared laugh, pleasant campfire talk
-+2/+5 ... Genuine compliment, meaningful help with a problem, bonding over shared interests
-+5/+10 .. Surviving danger together, real heartfelt conversation, completing a shared goal
-+10/+15 . Protecting or defending them, significant act of loyalty, keeping a difficult promise
-+15/+25 . Saving their life, major self-sacrifice for their sake
+FRIENDSHIP scale (guides, not hard rules):
++1/+2 ... Casual warmth, shared laugh, pleasant campfire talk, small kindness
++2/+5 ... Compliment, meaningful help, bonding over shared memories or interests
++5/+10 .. Surviving danger together, heartfelt conversation, completing a shared goal
++10/+15 . Defending/protecting them, act of loyalty, keeping a difficult promise
++15/+25 . Saving their life, major self-sacrifice
 +25/+30 . Blood oath, brotherhood/sisterhood pact
--1/-3 ... Being dismissive, forgetting something they told you, mild rudeness
--3/-5 ... Minor let-down, small broken promise, ignoring them in a group
--5/-10 .. Insult, dismissal, belittling, disrespecting their beliefs
+-1/-3 ... Dismissiveness, mild rudeness, forgetting something important to them
+-3/-5 ... Small broken promise, ignoring them in a group, letting them down
+-5/-10 .. Insult, belittling, disrespecting their values or beliefs
 -10/-20 . Public humiliation, badmouthing them (if overheard)
 -20/-30 . Abandoning them in danger, breaking a major promise
 -40/-60 . Betraying them to an enemy
 
-AFFECTION EXAMPLES (guides, not hard rules):
-+1 ...... Subtle kind gesture, attentive small detail, noticing something about them
-+2/+3 ... Sincere compliment on appearance, wit, or spirit
-+5/+10 .. Sweet gift, emotional gesture, intimate conversation, shared vulnerability
-+10/+20 . Protective act (romantic context), vulnerable confession of feelings
+AFFECTION scale (guides, not hard rules):
++1 ...... Subtle kind gesture, noticing a small detail about them
++2/+3 ... Sincere compliment on appearance, wit, or spirit; flirtatious banter (if receptive)
++5/+10 .. Meaningful gift, intimate conversation, shared vulnerability, romantic gesture
++10/+20 . Protective act in romantic context, vulnerable confession of feelings
 +20/+30 . Romantic proposal (if receptive)
 -1/-2 ... Awkward or tone-deaf comment, mild social blunder
--2/-3 ... Cold or dismissive behavior (per instance)
+-2/-3 ... Cold or dismissive behavior
 -5/-10 .. Public rejection or embarrassment
 -8/-15 .. Flirting with someone else in their presence
 -40/-60 . Romantic betrayal or cheating
 
-Typical range: 1-5 for minor moments, 5-15 for major events. Only use 15+ for life-altering moments.
+Typical range: 1-5 for minor moments, 5-15 for major events. Only use 15+ for life-altering ones.
 
 EXAMPLE — end of a response where {{user}} complimented Elena:
 *(Affection: Elena +2 — she seemed genuinely moved by the words)*

--- a/sysprompt_legacy.txt
+++ b/sysprompt_legacy.txt
@@ -255,6 +255,52 @@ Status: Condition
 - Short Rest interruption: also active, but the DC should be easier, generally lower than DC 8 unless the area is extremely hostile and dangerous.
 </resting>
 
+<relationship_tracking>
+RELATIONSHIP TRACKING — only active when [NPC_RELATIONS] appears in context.
+
+[NPC_RELATIONS] at the top of each turn shows current standings with active NPCs. Scale: -100 (deep hostility) to +100 (deep bond). Friendship = platonic trust. Affection = romantic/emotional warmth.
+
+WHEN TO EMIT:
+Be selective and natural about it. Only emit when {{user}} directly and meaningfully interacted with an NPC in this response — a real moment worth noting. An NPC being referenced, mentioned, or discussed by others does not warrant a tag.
+
+INLINE ANNOTATION (visible — place immediately after the triggering moment):
+*(Friendship: Marcus +10 — saved his life in the alley)*
+*(Affection: Elena +2 — she seemed touched by the compliment)*
+
+MACHINE TAGS (stripped before display — place ALL at the very end of the response, one per line):
+[REL: FirstName | field | delta]
+  FirstName = NPC's first name only | field = friendship or affection | delta = signed integer
+
+FRIENDSHIP EXAMPLES (guides, not hard rules):
++1/+2 ... Small warmth, casual kindness, shared laugh
++2/+5 ... Genuine compliment, meaningful help with a problem
++5/+10 .. Surviving danger together, real heartfelt conversation
++10/+15 . Protecting or defending them, significant act of loyalty
++15/+25 . Saving their life
++25/+30 . Blood oath, brotherhood/sisterhood pact
+-3/-5 ... Minor let-down, small broken promise
+-5/-10 .. Insult, dismissal, belittling
+-10/-20 . Public humiliation, badmouthing them (if overheard)
+-20/-30 . Abandoning them in danger
+-40/-60 . Betraying them to an enemy
+
+AFFECTION EXAMPLES (guides, not hard rules):
++1 ...... Subtle kind gesture, attentive small detail
++2/+3 ... Sincere compliment on appearance, wit, or spirit
++5/+10 .. Sweet gift, emotional gesture, intimate conversation
++10/+20 . Protective act (romantic context), vulnerable confession
++20/+30 . Romantic proposal (if receptive)
+-2/-3 ... Cold or dismissive behavior (per instance)
+-5/-10 .. Public rejection or embarrassment
+-8/-15 .. Flirting with someone else in their presence
+-40/-60 . Romantic betrayal or cheating
+
+EXAMPLE — end of a response where {{user}} complimented Elena:
+*(Affection: Elena +2 — she seemed genuinely moved by the words)*
+
+[REL: Elena | affection | +2]
+</relationship_tracking>
+
 <state_memo>
 - ## TRACKER STATE 0 (Current) is passed on every turn; its mechanical data is absolute law.
 - Ignore any formatting data such as ((PILLS)).

--- a/sysprompt_legacy.txt
+++ b/sysprompt_legacy.txt
@@ -261,28 +261,9 @@ RELATIONSHIP TRACKING — only active when [NPC_RELATIONS] appears in context.
 [NPC_RELATIONS] at the top of each turn shows current standings with active NPCs. Scale: -100 (deep hostility) to +100 (deep bond). Friendship = platonic trust. Affection = romantic/emotional warmth.
 
 WHEN TO EMIT:
-Be selective and natural about it. Only emit when {{user}} directly and meaningfully interacted with an NPC in this response — a real moment worth noting. An NPC being referenced, mentioned, or discussed by others does not warrant a tag.
+Be selective and natural. Only emit when {{user}} directly and meaningfully interacted with an NPC — a real moment worth noting. Magnitude MUST reflect the NPC's personality: a stoic warrior shifts less than a warm innkeeper for the same act.
 
-Relationship shifts are NOT limited to obvious social acts. Consider ALL of the following (non-exhaustive — use your judgment for ANY situation):
-• Direct compliments, insults, gifts, threats, apologies
-• Sharing a meal, campfire conversation, bonding over shared interests or memories
-• Surviving danger together, escaping a trap, enduring hardship side by side
-• Completing a quest that matters to the NPC, fulfilling a promise made to them
-• Betrayal, breaking a promise, abandoning or failing to protect them
-• Saving their life or a loved one's life
-• Flirtatious banter — received well OR poorly depending on the NPC's current feelings
-• A meaningful personal confession, a vulnerable moment shared
-• A romantic gesture — a dance, a gift with personal significance, a protective act in romantic context
-• Spending extended quality time together with positive interactions
-• Disrespecting their values, culture, religion, or loved ones
-• Ignoring them, forgetting something important to them, treating them as unimportant
-
-MAGNITUDE MUST reflect the NPC's personality. A stoic warrior might shift +1 where a warm innkeeper shifts +3 for the same compliment. Personality matters more than the act itself — gauge against WHO the NPC is, their temperament, values, and what they care about.
-
-DO NOT EMIT when:
-• The interaction is purely transactional with no emotional weight (buying supplies, asking for directions)
-• The NPC is not present or participating in the scene
-• Nothing meaningful happened between {{user}} and the specific NPC this turn
+DO NOT EMIT when: the interaction has no emotional weight (buying supplies, directions), the NPC is absent, or nothing meaningful happened between {{user}} and that NPC this turn.
 
 INLINE ANNOTATION (visible — place immediately after the triggering moment):
 *(Friendship: Marcus +10 — saved his life in the alley)*
@@ -292,33 +273,33 @@ MACHINE TAGS (stripped before display — place ALL at the very end of the respo
 [REL: FirstName | field | delta]
   FirstName = NPC's first name only | field = friendship or affection | delta = signed integer
 
-FRIENDSHIP EXAMPLES (guides, not hard rules):
-+1/+2 ... Small warmth, casual kindness, shared laugh, pleasant campfire talk
-+2/+5 ... Genuine compliment, meaningful help with a problem, bonding over shared interests
-+5/+10 .. Surviving danger together, real heartfelt conversation, completing a shared goal
-+10/+15 . Protecting or defending them, significant act of loyalty, keeping a difficult promise
-+15/+25 . Saving their life, major self-sacrifice for their sake
+FRIENDSHIP scale (guides, not hard rules):
++1/+2 ... Casual warmth, shared laugh, pleasant campfire talk, small kindness
++2/+5 ... Compliment, meaningful help, bonding over shared memories or interests
++5/+10 .. Surviving danger together, heartfelt conversation, completing a shared goal
++10/+15 . Defending/protecting them, act of loyalty, keeping a difficult promise
++15/+25 . Saving their life, major self-sacrifice
 +25/+30 . Blood oath, brotherhood/sisterhood pact
--1/-3 ... Being dismissive, forgetting something they told you, mild rudeness
--3/-5 ... Minor let-down, small broken promise, ignoring them in a group
--5/-10 .. Insult, dismissal, belittling, disrespecting their beliefs
+-1/-3 ... Dismissiveness, mild rudeness, forgetting something important to them
+-3/-5 ... Small broken promise, ignoring them in a group, letting them down
+-5/-10 .. Insult, belittling, disrespecting their values or beliefs
 -10/-20 . Public humiliation, badmouthing them (if overheard)
 -20/-30 . Abandoning them in danger, breaking a major promise
 -40/-60 . Betraying them to an enemy
 
-AFFECTION EXAMPLES (guides, not hard rules):
-+1 ...... Subtle kind gesture, attentive small detail, noticing something about them
-+2/+3 ... Sincere compliment on appearance, wit, or spirit
-+5/+10 .. Sweet gift, emotional gesture, intimate conversation, shared vulnerability
-+10/+20 . Protective act (romantic context), vulnerable confession of feelings
+AFFECTION scale (guides, not hard rules):
++1 ...... Subtle kind gesture, noticing a small detail about them
++2/+3 ... Sincere compliment on appearance, wit, or spirit; flirtatious banter (if receptive)
++5/+10 .. Meaningful gift, intimate conversation, shared vulnerability, romantic gesture
++10/+20 . Protective act in romantic context, vulnerable confession of feelings
 +20/+30 . Romantic proposal (if receptive)
 -1/-2 ... Awkward or tone-deaf comment, mild social blunder
--2/-3 ... Cold or dismissive behavior (per instance)
+-2/-3 ... Cold or dismissive behavior
 -5/-10 .. Public rejection or embarrassment
 -8/-15 .. Flirting with someone else in their presence
 -40/-60 . Romantic betrayal or cheating
 
-Typical range: 1-5 for minor moments, 5-15 for major events. Only use 15+ for life-altering moments.
+Typical range: 1-5 for minor moments, 5-15 for major events. Only use 15+ for life-altering ones.
 
 EXAMPLE — end of a response where {{user}} complimented Elena:
 *(Affection: Elena +2 — she seemed genuinely moved by the words)*

--- a/sysprompt_legacy.txt
+++ b/sysprompt_legacy.txt
@@ -263,6 +263,27 @@ RELATIONSHIP TRACKING — only active when [NPC_RELATIONS] appears in context.
 WHEN TO EMIT:
 Be selective and natural about it. Only emit when {{user}} directly and meaningfully interacted with an NPC in this response — a real moment worth noting. An NPC being referenced, mentioned, or discussed by others does not warrant a tag.
 
+Relationship shifts are NOT limited to obvious social acts. Consider ALL of the following (non-exhaustive — use your judgment for ANY situation):
+• Direct compliments, insults, gifts, threats, apologies
+• Sharing a meal, campfire conversation, bonding over shared interests or memories
+• Surviving danger together, escaping a trap, enduring hardship side by side
+• Completing a quest that matters to the NPC, fulfilling a promise made to them
+• Betrayal, breaking a promise, abandoning or failing to protect them
+• Saving their life or a loved one's life
+• Flirtatious banter — received well OR poorly depending on the NPC's current feelings
+• A meaningful personal confession, a vulnerable moment shared
+• A romantic gesture — a dance, a gift with personal significance, a protective act in romantic context
+• Spending extended quality time together with positive interactions
+• Disrespecting their values, culture, religion, or loved ones
+• Ignoring them, forgetting something important to them, treating them as unimportant
+
+MAGNITUDE MUST reflect the NPC's personality. A stoic warrior might shift +1 where a warm innkeeper shifts +3 for the same compliment. Personality matters more than the act itself — gauge against WHO the NPC is, their temperament, values, and what they care about.
+
+DO NOT EMIT when:
+• The interaction is purely transactional with no emotional weight (buying supplies, asking for directions)
+• The NPC is not present or participating in the scene
+• Nothing meaningful happened between {{user}} and the specific NPC this turn
+
 INLINE ANNOTATION (visible — place immediately after the triggering moment):
 *(Friendship: Marcus +10 — saved his life in the alley)*
 *(Affection: Elena +2 — she seemed touched by the compliment)*
@@ -272,28 +293,32 @@ MACHINE TAGS (stripped before display — place ALL at the very end of the respo
   FirstName = NPC's first name only | field = friendship or affection | delta = signed integer
 
 FRIENDSHIP EXAMPLES (guides, not hard rules):
-+1/+2 ... Small warmth, casual kindness, shared laugh
-+2/+5 ... Genuine compliment, meaningful help with a problem
-+5/+10 .. Surviving danger together, real heartfelt conversation
-+10/+15 . Protecting or defending them, significant act of loyalty
-+15/+25 . Saving their life
++1/+2 ... Small warmth, casual kindness, shared laugh, pleasant campfire talk
++2/+5 ... Genuine compliment, meaningful help with a problem, bonding over shared interests
++5/+10 .. Surviving danger together, real heartfelt conversation, completing a shared goal
++10/+15 . Protecting or defending them, significant act of loyalty, keeping a difficult promise
++15/+25 . Saving their life, major self-sacrifice for their sake
 +25/+30 . Blood oath, brotherhood/sisterhood pact
--3/-5 ... Minor let-down, small broken promise
--5/-10 .. Insult, dismissal, belittling
+-1/-3 ... Being dismissive, forgetting something they told you, mild rudeness
+-3/-5 ... Minor let-down, small broken promise, ignoring them in a group
+-5/-10 .. Insult, dismissal, belittling, disrespecting their beliefs
 -10/-20 . Public humiliation, badmouthing them (if overheard)
--20/-30 . Abandoning them in danger
+-20/-30 . Abandoning them in danger, breaking a major promise
 -40/-60 . Betraying them to an enemy
 
 AFFECTION EXAMPLES (guides, not hard rules):
-+1 ...... Subtle kind gesture, attentive small detail
++1 ...... Subtle kind gesture, attentive small detail, noticing something about them
 +2/+3 ... Sincere compliment on appearance, wit, or spirit
-+5/+10 .. Sweet gift, emotional gesture, intimate conversation
-+10/+20 . Protective act (romantic context), vulnerable confession
++5/+10 .. Sweet gift, emotional gesture, intimate conversation, shared vulnerability
++10/+20 . Protective act (romantic context), vulnerable confession of feelings
 +20/+30 . Romantic proposal (if receptive)
+-1/-2 ... Awkward or tone-deaf comment, mild social blunder
 -2/-3 ... Cold or dismissive behavior (per instance)
 -5/-10 .. Public rejection or embarrassment
 -8/-15 .. Flirting with someone else in their presence
 -40/-60 . Romantic betrayal or cheating
+
+Typical range: 1-5 for minor moments, 5-15 for major events. Only use 15+ for life-altering moments.
 
 EXAMPLE — end of a response where {{user}} complimented Elena:
 *(Affection: Elena +2 — she seemed genuinely moved by the words)*


### PR DESCRIPTION
## [3.8.9] - 2026-07-01

### Fixed
- **NPC Portrait Generation Routing**: Fixed a bug where auto-generating portraits for NPCs incorrectly used the default Portrait AI connection settings instead of the dedicated Lorebook Agent AI connection settings, ensuring context-aware models handle the complex lorebook generation.
- **NPC Word Count Cap**: Raised the internal hard cap for NPC major/minor section word targets from 100 to 1,000 words. Previously, typing a value like `400` in settings would silently clamp and save as `100`, forcing the AI to abbreviate lore. The quick-settings popup and main extension panel now correctly persist custom large limits.

## [3.8.8] - 2026-06-30

### Added
- **Relationship Bars System Rework**: Overhauled the NPC relationship bar system from a cosmetic feature into a functional, AI-driven mechanic. The narrator AI now emits inline annotations (e.g. `*(Affection: Elena +2 — sincere compliment)*`) at the point of interaction and machine tags (`[REL: Name | field | delta]`) at the end of each response. Tags are automatically parsed, deltas applied to the relationship bars (clamped ±100), and the updated values written back to lorebook NPC entries as the persistent campaign database. Context injection (`[NPC_RELATIONS]`) provides the narrator with a live snapshot of current standings for active NPCs only, keeping token usage minimal. System prompt guidance added with calibrated delta examples for both Friendship and Affection.
- **Always Auto-Generate NPCs (Lorebook)**: Introduced a new settings toggle to automatically generate portraits in the background for new or updated NPCs created by the Lorebook Agent, aligning the behavior with existing auto-generation options for Party and Enemies.