### PR TITLE
Fix mergeQuestUpdates() unable to create new quests from the State Extractor diff

### DIFF
--- a/memo-processor.js
+++ b/memo-processor.js
@@ -291,8 +291,6 @@ export function mergeQuestUpdates(jsonText, memoText = null) {
     const settings = getSettings();
     const target = (memoText !== null) ? memoText : settings.currentMemo;
     const quests = parseQuestsFromMemo(target);
-    
-    if (!quests.length) return target;
 
     let parsed;
     try {
@@ -308,6 +306,13 @@ export function mergeQuestUpdates(jsonText, memoText = null) {
     const mods = settings.syspromptModules || {};
     const isDeadlines = !!mods.questsDeadlines;
     const isFrustration = !!mods.questsFrustration;
+
+    const tMatch = target?.match(/\[TIME\]([\s\S]*?)\[\/TIME\]/i);
+    let acceptedTime = "08:00 AM, Day 1";
+    if (tMatch) {
+        const timeStr = extractCurrentTimeStr(tMatch[1]);
+        if (timeStr) acceptedTime = timeStr;
+    }
 
     let changed = false;
     for (const update of updates) {
@@ -325,7 +330,29 @@ export function mergeQuestUpdates(jsonText, memoText = null) {
             }
         }
 
-        if (!quest) continue;
+        if (!quest) {
+            // No existing quest or objective matches this id — this is a brand-new quest.
+            // The extractor's diff schema only sends {id, status, difficulty, objectives},
+            // so synthesize sane defaults for the fields LogQuest would normally populate.
+            if (!update.id) continue;
+            const firstObjText = Array.isArray(update.objectives) && update.objectives[0]?.text;
+            quest = {
+                id: update.id,
+                title: update.title || firstObjText || `Quest ${update.id}`,
+                giver_name: update.giver_name || 'Unknown',
+                giver_location: update.giver_location || 'Unknown Location',
+                objectives: [],
+                rewards: Array.isArray(update.rewards) ? update.rewards : [],
+                difficulty: update.difficulty,
+                deadline_time: isDeadlines ? (update.deadline_time || null) : undefined,
+                frustration_coefficient: isFrustration ? (update.frustration_coefficient || 1.0) : undefined,
+                auto_fail: (isDeadlines && !isFrustration),
+                accepted_time: acceptedTime,
+                status: ['active', 'completed', 'failed', 'past deadline'].includes(update.status) ? update.status : 'active',
+            };
+            quests.push(quest);
+            changed = true;
+        }
         if (quest.status === 'failed') continue;
 
         if (objectiveDirectUpdate) {


### PR DESCRIPTION
## Summary

`mergeQuestUpdates()` (memo-processor.js) applies the `[QUESTS]` JSON diff the State Extractor model emits, but it can only ever *update* quests/objectives that already exist in the memo:

- It returns immediately if `parseQuestsFromMemo(target)` is empty, before even parsing the incoming diff:
  ```js
  const quests = parseQuestsFromMemo(target);
  if (!quests.length) return target;
  ```
- Further down, any update whose `id` doesn't match an existing quest or objective is silently dropped:
  ```js
  if (!quest) continue;
  ```

Per `sysprompt.txt`, new quests are documented as being created via the `LogQuest` tool, with the `[QUESTS]` diff format reserved for status/objective updates. In practice though, the State Extractor model *does* emit fresh quest objects into the diff (an `id` with no matching prior quest, full `objectives` array, etc.) whenever it infers a new quest from the narrative — and those were being silently discarded, with no warning, no log line, nothing. I confirmed this via debug console output: `mergeMemo: found N tag(s)` correctly counted the `[QUESTS]` tag, but nothing downstream ever logged applying it, and the quest never appeared on the character sheet.

Repro: player accepts a quest narratively (or the DM confirms one), the State Extractor's next pass emits a valid `{"updates":[{"id":"q1","status":"active","difficulty":"medium","objectives":[...]}]}` block for a quest that doesn't exist yet in the memo — it vanishes.

## Fix

Adds a "create" branch: when no existing quest or objective matches `update.id`, synthesize a new quest object (with sane defaults for fields the diff format doesn't carry — `title`/`giver_name`/`giver_location` — since the extractor's diff schema only sends `id`/`status`/`difficulty`/`objectives`) and push it into the quest array instead of skipping it. The existing per-objective "add new objective" logic further down (the `else if (objUpdate.text)` branch) naturally populates `update.objectives` onto the freshly created quest, so no separate objective-building logic was needed — I just start the new quest with an empty `objectives: []` and let that code do its job.

I also had to remove the early `if (!quests.length) return target;` bailout, since a chat that has zero *existing* quests (e.g. quest tracking got reset, or these are simply the first quests of the campaign) would otherwise never be able to create its first quest via this path either.

## Notes for the maintainer

The default values I picked (`title` falls back to the first objective's text, `giver_name`/`giver_location` fall back to `'Unknown'`) are a judgment call — happy to adjust to whatever fits the project's conventions better, e.g. if you'd rather have the State Extractor's prompt updated to also request `title`/`giver_name`/`giver_location` in the diff for new quests instead of synthesizing defaults client-side.

## Test plan
- [x] `node --check` passes on the modified file
- [x] Verified via a live campaign: an accepted quest that previously never appeared on the character sheet now creates correctly through this path