### PR TITLE
Always route sendAgentTurn requests through the CORS proxy

### DIFF
--- a/llm-client.js
+++ b/llm-client.js
@@ -557,19 +557,20 @@ export async function sendAgentTurn(settings, messages, tools = null, signal = n
         if (tools?.length) body.tools = tools;
         if (settings.maxTokens > 0) body.max_tokens = settings.maxTokens;
 
-        const isLocal = /^https?:\/\/(localhost|127\.0\.0\.1|192\.168\.\d+|10\.\d|172\.(1[6-9]|2\d|3[01])\.)/i.test(endpoint);
+        // PATCH: always route through ST's server-side CORS proxy (requires enableCorsProxy).
+        // Browser-direct fetches to remote endpoints (e.g. opencode.ai) fail CORS preflight.
         let resp;
-        if (isLocal) {
-            try {
-                resp = await fetch(proxiedUrl(endpoint), { method: 'POST', headers: { ...headers, ...getProxyHeaders() }, body: JSON.stringify(body), signal });
-                if (!resp.ok && resp.status === 404) throw new Error('proxy 404');
-            } catch (_) {
-                resp = await fetch(endpoint, { method: 'POST', headers, body: JSON.stringify(body), credentials: 'omit', signal });
-            }
-        } else {
+        try {
+            resp = await fetch(proxiedUrl(endpoint), { method: 'POST', headers: { ...headers, ...getProxyHeaders() }, body: JSON.stringify(body), signal });
+            if (!resp.ok && resp.status === 404) throw new Error('proxy 404');
+        } catch (_) {
             resp = await fetch(endpoint, { method: 'POST', headers, body: JSON.stringify(body), credentials: 'omit', signal });
         }
-        if (!resp.ok) throw new Error(`OpenAI request failed (${resp.status})`);
+        if (!resp.ok) {
+            let _body = '';
+            try { _body = await resp.text(); } catch (_) {}
+            throw new Error(`OpenAI request failed (${resp.status}): ${_body.slice(0, 600)}`);
+        }
         const data = await resp.json();
         const msg = data.choices?.[0]?.message;
         if (msg?.tool_calls?.length) {


### PR DESCRIPTION
## Summary

`sendAgentTurn()` in `llm-client.js` only routed requests through ST's server-side CORS proxy (`proxiedUrl()`/`getProxyHeaders()`) when the target endpoint matched a \"local\" heuristic (localhost/private-IP regex):

```js
const isLocal = /^https?:\/\/(localhost|127\.0\.0\.1|192\.168\.\d+|10\.\d|172\.(1[6-9]|2\d|3[01])\.)/i.test(endpoint);
```

Everything else went out as a direct browser `fetch()`. Direct fetches to remote OpenAI-compatible endpoints (I hit this against `opencode.ai`) fail CORS preflight, since the remote server has no reason to allow the SillyTavern origin — so any agent turn on this code path (used by the Lorebook Agent / State Extractor tool-calling flow) silently fails for anyone using a non-local backend.

## Fix

Always route through the proxy first (same as the rest of the extension's request paths already assume, per `enableCorsProxy`), falling back to a direct fetch only if the proxied request itself throws or 404s — this preserves existing behavior for setups that don't have the proxy enabled, it just stops skipping the proxy for remote endpoints that actually need it.

Also included: surfacing the response body text on a failed request (`OpenAI request failed (${status}): ${body}`) instead of just the bare status code — made diagnosing this considerably faster and seems generally useful for anyone debugging a misconfigured endpoint.

## Test plan
- [x] `node --check` passes
- [x] Confirmed against a live campaign: agent turns against a remote (non-local) endpoint that previously failed CORS preflight now succeed