### PR TITLE
Pass reasoning_content back on replayed tool-call turns for thinking models

### DIFF
--- a/llm-client.js
+++ b/llm-client.js
@@ -572,14 +572,15 @@ export async function sendAgentTurn(settings, messages, tools = null, signal = n
         if (!resp.ok) throw new Error(`OpenAI request failed (${resp.status})`);
         const data = await resp.json();
         const msg = data.choices?.[0]?.message;
+        const _reasoning = msg?.reasoning_content ?? msg?.reasoning ?? null;
         if (msg?.tool_calls?.length) {
             const tc = msg.tool_calls[0];
             let args;
             try { args = JSON.parse(tc.function.arguments); } catch (_) { args = {}; }
-            return { content: msg.content || '', toolCall: { name: tc.function.name, args, id: tc.id } };
+            return { content: msg.content || '', reasoning: _reasoning, toolCall: { name: tc.function.name, args, id: tc.id } };
         }
         const text = msg?.content ?? data.choices?.[0]?.text ?? '';
-        return { content: text, toolCall: null };
+        return { content: text, reasoning: _reasoning, toolCall: null };
     }
 
     // ── Ollama ───────────────────────────────────────────────────────────────

--- a/router.js
+++ b/router.js
@@ -713,11 +713,13 @@ Action: commit({"rewrite": [{"id": "Eldoria_Events::3", "content": "Compressed v
                 const callId = /** @type {any} */ (resolvedToolCall).id || `call_cleanup_${Date.now()}_${cleanupTurns}`;
                 broadcastStep('tool', `${toolName}(...)`);
 
-                cleanupMessages.push({
+                const _asstCleanup = {
                     role: 'assistant',
                     content: result.content || null,
                     tool_calls: [{ id: callId, type: 'function', function: { name: toolName, arguments: JSON.stringify(args) } }]
-                });
+                };
+                if (result.reasoning) _asstCleanup.reasoning_content = result.reasoning;
+                cleanupMessages.push(_asstCleanup);
 
                 let observation = '';
                 if (toolName === 'commit') {
@@ -1177,8 +1179,9 @@ ${sharedContext}`;
                 const callId = /** @type {any} */ (resolvedToolCall).id || `call_${Date.now()}_${turns}`;
                 broadcastStep('tool', `${toolName}(...)`);
 
-                // Append the assistant turn (with tool_calls) to the conversation
-                messages.push({
+                // Append the assistant turn (with tool_calls) to the conversation.
+                // DeepSeek thinking models require reasoning_content to be passed back.
+                const _asstMsg = {
                     role: 'assistant',
                     content: result.content || null,
                     tool_calls: [{
@@ -1186,7 +1189,9 @@ ${sharedContext}`;
                         type: 'function',
                         function: { name: toolName, arguments: JSON.stringify(args) }
                     }]
-                });
+                };
+                if (result.reasoning) _asstMsg.reasoning_content = result.reasoning;
+                messages.push(_asstMsg);
 
                 let observation = '';
 


### PR DESCRIPTION
## Summary

`sendAgentTurn()` reads the raw API response but discards `message.reasoning_content` (or `message.reasoning`, depending on provider) entirely. For DeepSeek-style thinking/reasoning models, that field needs to be echoed back on the assistant message when the conversation continues after a tool call — some of these models degrade in quality or reject the follow-up request outright without it, since it's part of the expected multi-turn contract for reasoning models.

This surfaced while debugging an unrelated issue (agent tool calls not completing reliably against a reasoning model backend) — router.js's tool-call reply loop was silently dropping the model's reasoning between turns.

## Fix

- **`llm-client.js`**: `sendAgentTurn()` now extracts `reasoning_content ?? reasoning ?? null` from the response and includes it (as `reasoning`) alongside `content`/`toolCall` in its return value.
- **`router.js`**: both places that replay an assistant turn containing a tool call (the cleanup pass and the main agent-turn loop) now attach `result.reasoning` as `reasoning_content` on the pushed message, when present.

This is a no-op for any model/provider that doesn't return `reasoning_content` — the field is simply absent and nothing changes.

## Test plan
- [x] `node --check` passes on both modified files
- [x] Verified via a live campaign against a reasoning-capable backend — multi-turn tool-call sequences that previously misbehaved now carry reasoning context correctly between turns