### PR TITLE
Fix NPC cards that exist in the lorebook but never reach the prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to the **Multihog D&D Framework** will be documented in this
 
 ## [Unreleased]
 
+### Fixed
+- **New NPC cards missing from the prompt until Activate / Refresh Manifest**: Add NPC now records the book on `campaignBooks`, writes ST's world-info cache, and persists settings so the next generate can inject the card. Agent-owned lore injects even when Native Keyword Activation is on (or the user message has no extractable text), instead of listing the NPC only in `[NPC_RELATIONS]`. The keyword scanner unions the ownership list with the in-memory registry so a newly created NPCs book is not skipped. A full manifest refresh copies disk-fresh entries back into ST's cache.
+
 ## [7.95.3] - 2026-08-16
 
 ### Changed

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ import { renderSubFieldByRule, tryRenderMarker, renderCustomBlockLine, stripMemo
 import { unregisterLogQuestTool, checkQuestDeadlines, renderQuestsAsPlainText } from './quests.js';
 import { initializeDebugViewer, toggleDebugViewer } from './debug-viewer.js';
 import { installSwipeSchedulerDebug } from './swipe-scheduler-debug.js';
-import { runRouterPass, rollbackRouterPass, reapplyRouterPass, captureRouterLoreState, captureActiveDungeonMapHistory, restoreActiveDungeonMapHistory, getLorebookManifest, deleteLorebookEntry, updateLorebookEntry, disableManagedEntries, isRouterRunning, stopRouterPass, purgeWorldHistoryForChat, setLorebookEntryPinned } from './router.js';
+import { runRouterPass, rollbackRouterPass, reapplyRouterPass, captureRouterLoreState, captureActiveDungeonMapHistory, restoreActiveDungeonMapHistory, getLorebookManifest, deleteLorebookEntry, updateLorebookEntry, disableManagedEntries, isRouterRunning, stopRouterPass, purgeWorldHistoryForChat, setLorebookEntryPinned, rememberCampaignBook, updateWorldInfoCache } from './router.js';
 import { isMapUpdaterRunning, runMapUpdaterPass, stopMapUpdaterPass } from './map-updater.js';
 import { isMapEvolutionRunning, listMappedEvolutionSites, loadMappedEvolutionSite, runMapEvolutionPass, stopMapEvolutionPass } from './map-evolution.js';
 import { summarizeMapEvolutionSchedule, stampEvolutionLastFired } from './map-evolution-lib.js';
@@ -4223,6 +4223,8 @@ function createPanel() {
         updateAgentStatusIndicator,
         updateChatLinkUI,
         updateLorebookEntry,
+        updateWorldInfoCache,
+        rememberCampaignBook,
         updatePanelStatus,
     });
 }

--- a/narrative-hooks.js
+++ b/narrative-hooks.js
@@ -1269,148 +1269,134 @@ export function installInterceptor() {
 
 
 
-        // Pre-generation keyword scan.
-        // This interceptor (manifest generate_interceptor) fires BEFORE addPromptManagerInterceptor
-        // in the ST pipeline. Running the keyword scan here ensures that any entries activated by
-        // the current user message land in activeRouterKeys before Path 1 reads it.
-        //
-        // In Path 1 (skipInjection=true): scan runs, activeRouterKeys is updated, text building
-        //   is skipped. Path 1 will pick up all activeRouterKeys (including newly triggered ones)
-        //   and inject them as a single system message at the configured depth.
-        //
-        // In Path 2 (skipInjection=false): scan runs and we also build lore text and inject it
-        //   directly into the user message (legacy path for old ST builds).
-        //
-        // Skipped entirely when routerNativeKeywordActivation is enabled (ST handles keywords).
-        if (settings.routerEnabled && !settings.routerNativeKeywordActivation) {
-            if (content) {
-                const t0 = performance.now().toFixed(1);
-                console.group(`[RPG|INTERCEPT] rpgTrackerInterceptor keyword pre-scan @ ${t0}ms`);
-                console.log('skipInjection (Path 1 active):', skipInjection);
-                console.log('activeRouterKeys BEFORE scan:', JSON.stringify(settings.activeRouterKeys || []));
-                const triggered = await scanAssistantOutputForKeywords(content, { sweepEnabled: false }).catch(() => []);
-                console.log('activeRouterKeys AFTER scan:', JSON.stringify(settings.activeRouterKeys || []));
-                console.log('newly triggered this scan:', triggered);
-                console.log(`scan finished @ ${performance.now().toFixed(1) }ms`);
+        // Keyword scan is extension-managed only. Native Keyword Activation leaves
+        // matching to SillyTavern. Agent-owned cards still inject below either way —
+        // otherwise [NPC_RELATIONS] can list an NPC whose card never appears (ST
+        // native WI only injects when the book is selected and keys match).
+        let triggered = [];
+        if (settings.routerEnabled && !settings.routerNativeKeywordActivation && content) {
+            const t0 = performance.now().toFixed(1);
+            console.group(`[RPG|INTERCEPT] rpgTrackerInterceptor keyword pre-scan @ ${t0}ms`);
+            console.log('skipInjection (Path 1 active):', skipInjection);
+            console.log('activeRouterKeys BEFORE scan:', JSON.stringify(settings.activeRouterKeys || []));
+            triggered = await scanAssistantOutputForKeywords(content, { sweepEnabled: false }).catch(() => []);
+            console.log('activeRouterKeys AFTER scan:', JSON.stringify(settings.activeRouterKeys || []));
+            console.log('newly triggered this scan:', triggered);
+            console.log(`scan finished @ ${performance.now().toFixed(1) }ms`);
 
-                // Trigger UI refresh so the Agent Panel updates immediately with yellow pills
-                if (triggered.length > 0 && typeof globalThis._rpgRenderRouterUI === 'function') {
-                    globalThis._rpgRenderRouterUI();
-                }
+            if (triggered.length > 0 && typeof globalThis._rpgRenderRouterUI === 'function') {
+                globalThis._rpgRenderRouterUI();
+            }
+            console.groupEnd();
+        }
 
-                // In Path 1, the scan above already updated activeRouterKeys.
-                // Path 1's addPromptManagerInterceptor will read activeRouterKeys and inject
-                // all entries (including the newly triggered ones) at the configured depth.
-                // No text building or user-message mutation needed here.
-                if (!skipInjection) {
-                    // Path 2: build lore text to inject directly into the user message.
-                    if (triggered.length > 0) {
-                        try {
-                            const ctx = SillyTavern.getContext();
-                            let loreBlock = '';
-                            const bookCache = {};
-                            for (const id of triggered) {
-                                const [bookName, uid] = id.split('::');
-                                if (!bookCache[bookName]) bookCache[bookName] = await ctx.loadWorldInfo(bookName);
-                                const entry = bookCache[bookName]?.entries?.[uid];
-                                if (entry?.content) {
-                                    loreBlock += buildInjectedEntryText(id, entry, settings);
-                                }
-                            }
-                            if (loreBlock) {
-                                loreInjections += `\n<font color="#d4a028">## NEWLY ACTIVATED LORE (KEYWORD MATCH)</font>\n${loreBlock.trim()}\n`;
-                                console.log(`[RPG|INTERCEPT] Same-turn lore injected for ${triggered.length} entries.`);
-                            }
-                        } catch (e) {
-                            console.warn('[RPG Tracker] Same-turn lore injection failed:', e);
-                        }
-                    }
-
-                    // Persistent keyword-activated entries
-                    const triggeredSet = new Set(triggered);
-                    const persistent = (settings.keywordActivatedKeys || []).filter(id => !triggeredSet.has(id));
-                    if (persistent.length > 0) {
-                        try {
-                            const ctx = SillyTavern.getContext();
-                            let persistBlock = '';
-                            const bookCache = {};
-                            for (const id of persistent) {
-                                const [bookName, uid] = id.split('::');
-                                if (!bookCache[bookName]) bookCache[bookName] = await ctx.loadWorldInfo(bookName);
-                                const entry = bookCache[bookName]?.entries?.[uid];
-                                if (entry?.content) {
-                                    persistBlock += buildInjectedEntryText(id, entry, settings);
-                                }
-                            }
-                            if (persistBlock) {
-                                loreInjections += `\n<font color="#d4a028">## ACTIVE LORE (KEYWORD)</font>\n${persistBlock.trim()}\n`;
-                            }
-                        } catch (e) {
-                            console.warn('[RPG Tracker] Persistent keyword lore re-injection failed:', e);
-                        }
-                    }
-
-                    // Agent-owned entries (not keyword-triggered)
-                    const alreadyInjected = new Set([...triggered, ...(settings.keywordActivatedKeys || [])]);
-                    const agentOwned = (settings.activeRouterKeys || [])
-                        .filter(id => !alreadyInjected.has(id))
-                        .filter(id => {
-                            const [bookName] = id.split('::');
-                            const isWorld = bookName.toLowerCase().endsWith('_world') || bookName.toLowerCase() === 'world';
-                            return !isWorld;
-                        });
-                    if (agentOwned.length > 0) {
-                        try {
-                            const ctx = SillyTavern.getContext();
-                            let agentBlock = '';
-                            const bookCache = {};
-                            for (const id of agentOwned) {
-                                const [bookName, uid] = id.split('::');
-                                if (!bookCache[bookName]) bookCache[bookName] = await ctx.loadWorldInfo(bookName);
-                                const entry = bookCache[bookName]?.entries?.[uid];
-                                if (entry?.content) {
-                                    agentBlock += buildInjectedEntryText(id, entry, settings);
-                                }
-                            }
-                            if (agentBlock) {
-                                loreInjections += `\n## ACTIVE LORE (AGENT)\n${agentBlock.trim()}\n`;
-                            }
-                        } catch (e) {
-                            console.warn('[RPG Tracker] Agent-owned lore injection failed:', e);
-                        }
-                    }
-
-                // World Progression reports injection
-                if (settings.worldProgressionEnabled && (settings.activeWorldKeys || []).length > 0) {
+        if (settings.routerEnabled && !skipInjection) {
+            if (!settings.routerNativeKeywordActivation) {
+                if (triggered.length > 0) {
                     try {
                         const ctx = SillyTavern.getContext();
-                        let worldBlock = '';
+                        let loreBlock = '';
                         const bookCache = {};
-                        const sortedKeys = [...settings.activeWorldKeys].sort((a, b) => {
-                            const [, uidA] = a.split('::');
-                            const [, uidB] = b.split('::');
-                            return Number(uidA) - Number(uidB);
-                        });
-                        for (const id of sortedKeys) {
+                        for (const id of triggered) {
                             const [bookName, uid] = id.split('::');
                             if (!bookCache[bookName]) bookCache[bookName] = await ctx.loadWorldInfo(bookName);
                             const entry = bookCache[bookName]?.entries?.[uid];
                             if (entry?.content) {
-                                worldBlock += `### [${entry.key?.[0] || entry.comment || 'World Report'}]\n${substituteLoreMacros(entry.content)}\n\n`;
+                                loreBlock += buildInjectedEntryText(id, entry, settings);
                             }
                         }
-                        if (worldBlock) {
-                            wpInjections = `\n## WORLD PROGRESSION REPORTS\n${worldBlock.trim()}\n`;
+                        if (loreBlock) {
+                            loreInjections += `\n<font color="#d4a028">## NEWLY ACTIVATED LORE (KEYWORD MATCH)</font>\n${loreBlock.trim()}\n`;
+                            console.log(`[RPG|INTERCEPT] Same-turn lore injected for ${triggered.length} entries.`);
                         }
                     } catch (e) {
-                        console.warn('[RPG Tracker] World progression injection failed:', e);
+                        console.warn('[RPG Tracker] Same-turn lore injection failed:', e);
+                    }
+                }
+
+                const triggeredSet = new Set(triggered);
+                const persistent = (settings.keywordActivatedKeys || []).filter(id => !triggeredSet.has(id));
+                if (persistent.length > 0) {
+                    try {
+                        const ctx = SillyTavern.getContext();
+                        let persistBlock = '';
+                        const bookCache = {};
+                        for (const id of persistent) {
+                            const [bookName, uid] = id.split('::');
+                            if (!bookCache[bookName]) bookCache[bookName] = await ctx.loadWorldInfo(bookName);
+                            const entry = bookCache[bookName]?.entries?.[uid];
+                            if (entry?.content) {
+                                persistBlock += buildInjectedEntryText(id, entry, settings);
+                            }
+                        }
+                        if (persistBlock) {
+                            loreInjections += `\n<font color="#d4a028">## ACTIVE LORE (KEYWORD)</font>\n${persistBlock.trim()}\n`;
+                        }
+                    } catch (e) {
+                        console.warn('[RPG Tracker] Persistent keyword lore re-injection failed:', e);
                     }
                 }
             }
 
-            console.groupEnd();
+            // Agent-owned entries (not keyword-triggered). Always inject when the
+            // router is on — including native keyword mode and empty user messages.
+            const alreadyInjected = settings.routerNativeKeywordActivation
+                ? new Set()
+                : new Set([...triggered, ...(settings.keywordActivatedKeys || [])]);
+            const agentOwned = (settings.activeRouterKeys || [])
+                .filter(id => !alreadyInjected.has(id))
+                .filter(id => {
+                    const [bookName] = id.split('::');
+                    const isWorld = bookName.toLowerCase().endsWith('_world') || bookName.toLowerCase() === 'world';
+                    return !isWorld;
+                });
+            if (agentOwned.length > 0) {
+                try {
+                    const ctx = SillyTavern.getContext();
+                    let agentBlock = '';
+                    const bookCache = {};
+                    for (const id of agentOwned) {
+                        const [bookName, uid] = id.split('::');
+                        if (!bookCache[bookName]) bookCache[bookName] = await ctx.loadWorldInfo(bookName);
+                        const entry = bookCache[bookName]?.entries?.[uid];
+                        if (entry?.content) {
+                            agentBlock += buildInjectedEntryText(id, entry, settings);
+                        }
+                    }
+                    if (agentBlock) {
+                        loreInjections += `\n## ACTIVE LORE (AGENT)\n${agentBlock.trim()}\n`;
+                    }
+                } catch (e) {
+                    console.warn('[RPG Tracker] Agent-owned lore injection failed:', e);
+                }
+            }
+
+            if (settings.worldProgressionEnabled && (settings.activeWorldKeys || []).length > 0) {
+                try {
+                    const ctx = SillyTavern.getContext();
+                    let worldBlock = '';
+                    const bookCache = {};
+                    const sortedKeys = [...settings.activeWorldKeys].sort((a, b) => {
+                        const [, uidA] = a.split('::');
+                        const [, uidB] = b.split('::');
+                        return Number(uidA) - Number(uidB);
+                    });
+                    for (const id of sortedKeys) {
+                        const [bookName, uid] = id.split('::');
+                        if (!bookCache[bookName]) bookCache[bookName] = await ctx.loadWorldInfo(bookName);
+                        const entry = bookCache[bookName]?.entries?.[uid];
+                        if (entry?.content) {
+                            worldBlock += `### [${entry.key?.[0] || entry.comment || 'World Report'}]\n${substituteLoreMacros(entry.content)}\n\n`;
+                        }
+                    }
+                    if (worldBlock) {
+                        wpInjections = `\n## WORLD PROGRESSION REPORTS\n${worldBlock.trim()}\n`;
+                    }
+                } catch (e) {
+                    console.warn('[RPG Tracker] World progression injection failed:', e);
+                }
+            }
         }
-    }
 
         if (settings.debugMode) console.groupEnd();
 

--- a/router.js
+++ b/router.js
@@ -20,7 +20,7 @@ import {
     isLoreRedoEntryForChat,
     trimLoreHistoryForRollback,
 } from './src/state/lorebook-history.js';
-import { buildKeyringText, grepLoreInBooks, isSkeletonBookName } from './src/state/lorebook-keyring.js';
+import { buildKeyringText, grepLoreInBooks, isSkeletonBookName, resolveBooksToScan } from './src/state/lorebook-keyring.js';
 import {
     applyDungeonMapTransaction,
     attachDungeonMapToLocationEntry,
@@ -344,6 +344,28 @@ function getRouterChatId(ctx = SillyTavern.getContext()) {
         || null;
 }
 
+/**
+ * Record a lorebook on the active chat's campaignBooks list so boot / chat-switch
+ * `/world state=on` and the keyword scanner's fast path can find it. Newly created
+ * NPCs books were previously omitted here, so ST native WI and the scanner both
+ * skipped them until a manual Activate Campaign Lorebooks.
+ * @param {string} bookName
+ * @param {object} [settings]
+ * @returns {boolean} true when the list changed
+ */
+export function rememberCampaignBook(bookName, settings = getSettings()) {
+    if (!bookName) return false;
+    const chatId = getRouterChatId();
+    if (!chatId) return false;
+    settings.chatStates = settings.chatStates || {};
+    settings.chatStates[chatId] = settings.chatStates[chatId] || {};
+    const existing = new Set(settings.chatStates[chatId].campaignBooks || []);
+    const before = existing.size;
+    existing.add(bookName);
+    settings.chatStates[chatId].campaignBooks = [...existing];
+    return existing.size !== before;
+}
+
 function buildRouterLoreState(settings, { prefix, chatId, bookSnapshots }) {
     const chatState = chatId ? settings.chatStates?.[chatId] : null;
     return {
@@ -396,7 +418,7 @@ async function evictWorldInfoCache(bookName) {
     }
 }
 
-async function updateWorldInfoCache(bookName, bookData) {
+export async function updateWorldInfoCache(bookName, bookData) {
     try {
         const { worldInfoCache } = await import('../../../world-info.js');
         if (typeof worldInfoCache?.set !== 'function') return false;
@@ -3578,7 +3600,11 @@ export async function getLorebookManifest(skipUpdate = false) {
     const loadedBooks = await Promise.all(booksToLoad.map(async (n) => {
         try {
             const b = skipUpdate ? await ctx.loadWorldInfo(n) : await loadWorldInfoFresh(n, ctx);
-            return b?.entries ? { bookName: n, entries: b.entries } : null;
+            if (!b?.entries) return null;
+            // Full refreshes read disk; write that back so the interceptor's
+            // ctx.loadWorldInfo() sees the same entries the Agent UI just showed.
+            if (!skipUpdate) await updateWorldInfoCache(n, b);
+            return { bookName: n, entries: b.entries };
         } catch (_) {
             return null;
         }
@@ -3725,38 +3751,17 @@ export async function scanAssistantOutputForKeywords(narrativeText, opts = {}) {
     const prefix = getLivePrefix();
     if (!prefix) return [];
 
-    // Fast Path: use the campaignBooks ownership list if available.
-    // This avoids calling updateWorldInfoList() — the same 90-second registry scan
-    // that was causing the chat-switch latency — on EVERY generation.
+    // Fast path: campaignBooks avoids a disk re-index on every send. Union it
+    // with the in-memory registry so a newly created NPCs book that is not yet
+    // on the ownership list is still scanned (the exclusive fast path used to
+    // skip those books until Activate / Refresh Manifest).
     const chatId = typeof globalThis._rpgCurrentChatId === 'function' ? globalThis._rpgCurrentChatId() : null;
     const knownBooks = chatId ? (settings.chatStates?.[chatId]?.campaignBooks || []) : [];
-
-    let booksToScan;
-    if (knownBooks.length > 0) {
-        // We know exactly which books belong to this campaign — no registry scan needed.
-        booksToScan = [...knownBooks];
-    } else {
-        // Fallback for first-time chats: discover books via in-memory registry.
-        // updateWorldInfoList() is intentionally NOT called here — it triggers a
-        // full disk re-index on every message send, causing multi-second latency
-        // for users whose chatStates.campaignBooks is empty (new campaigns, no
-        // lorebook entries yet). The routerLog fallback below already catches any
-        // books not yet visible in the in-memory registry at zero I/O cost.
-        // runRouterPass calls updateWorldInfoList() after actual book writes (line ~1298),
-        // so the registry is already current by the time the next scan fires.
-        const allNames = await getWorldInfoNamesSafe();
-        const scoped = allNames.filter(n => bookBelongsToPrefix(n, prefix));
-
-        // Also sweep books referenced in routerLog (catches books not yet re-indexed)
-        const logBookNames = (settings.routerLog || [])
-            .flatMap(e => [...(e.record || []), ...(e.activate || [])].map(id => id.split('::')[0]))
-            .filter(Boolean);
-        const scopedSet = new Set(scoped);
-        for (const n of logBookNames) {
-            if (bookBelongsToPrefix(n, prefix) && !isSkeletonBookName(n)) scopedSet.add(n);
-        }
-        booksToScan = [...scopedSet];
-    }
+    const registryNames = await getWorldInfoNamesSafe({ fullProbe: knownBooks.length === 0 });
+    const logBookNames = (settings.routerLog || [])
+        .flatMap(e => [...(e.record || []), ...(e.activate || [])].map(id => id.split('::')[0]))
+        .filter(Boolean);
+    const booksToScan = resolveBooksToScan(knownBooks, registryNames, prefix, logBookNames);
 
     // ── Forward pass: activate entries whose keywords appear in the new narrative ──
     // ── or in the recent history window (Retroactive Lookback).            ──
@@ -4007,16 +4012,9 @@ export async function scanRecentOutputForPresentNpcs(narrativeText) {
 
     const chatId = typeof globalThis._rpgCurrentChatId === 'function' ? globalThis._rpgCurrentChatId() : null;
     const knownBooks = chatId ? (settings.chatStates?.[chatId]?.campaignBooks || []) : [];
-
-    let booksToScan;
-    if (knownBooks.length > 0) {
-        booksToScan = knownBooks.filter(n => isNpcBookName(n) && !isSkeletonBookName(n));
-    } else {
-        const allNames = await getWorldInfoNamesSafe({ fullProbe: false });
-        booksToScan = allNames.filter(n =>
-            bookBelongsToPrefix(n, prefix) && isNpcBookName(n) && !isSkeletonBookName(n),
-        );
-    }
+    const registryNames = await getWorldInfoNamesSafe({ fullProbe: knownBooks.length === 0 });
+    const booksToScan = resolveBooksToScan(knownBooks, registryNames, prefix)
+        .filter(n => isNpcBookName(n));
     if (!booksToScan.length) return [];
 
     const recentlyRecordedNpcIds = getRecentlyRecordedNpcIds(settings);

--- a/src/state/lorebook-keyring.js
+++ b/src/state/lorebook-keyring.js
@@ -1,6 +1,35 @@
+import { bookBelongsToCampaignPrefix } from './lorebook-history.js';
+
 /** World Skeleton lorebooks are hidden from Lorebook Agent tools and the keyring. */
 export function isSkeletonBookName(bookName) {
     return String(bookName || '').toLowerCase().endsWith('_skeleton');
+}
+
+/**
+ * Books the keyword / Present-Now scanners should open.
+ * `campaignBooks` is the fast ownership list, but it can lag behind a newly
+ * created NPCs book until the next Lorebook Agent pass. Union it with
+ * in-memory prefix-scoped names so a book that already exists in ST's
+ * registry is not skipped.
+ *
+ * @param {string[]} knownBooks campaignBooks for the active chat
+ * @param {string[]} registryNames in-memory (or probed) world-info names
+ * @param {string} prefix campaign prefix
+ * @param {string[]} [extraNames] e.g. books mentioned in routerLog
+ * @returns {string[]}
+ */
+export function resolveBooksToScan(knownBooks, registryNames, prefix, extraNames = []) {
+    const books = new Set();
+    const consider = (name) => {
+        if (!name) return;
+        if (!bookBelongsToCampaignPrefix(name, prefix)) return;
+        if (isSkeletonBookName(name)) return;
+        books.add(name);
+    };
+    for (const n of knownBooks || []) consider(n);
+    for (const n of registryNames || []) consider(n);
+    for (const n of extraNames || []) consider(n);
+    return [...books];
 }
 
 /**

--- a/src/ui/panel/panel-builder.js
+++ b/src/ui/panel/panel-builder.js
@@ -219,6 +219,8 @@ export function createPanel(dependencies) {
         updateAgentStatusIndicator,
         updateChatLinkUI,
         updateLorebookEntry,
+        updateWorldInfoCache,
+        rememberCampaignBook,
         updatePanelStatus,
     } = dependencies;
 
@@ -3269,20 +3271,17 @@ export function createPanel(dependencies) {
                 return false;
             }
 
-            // Sync in-memory cache
-            if (typeof ctx.saveWorldInfo === 'function') {
+            // Sync in-memory cache (HTTP edit bypasses ST's worldInfoCache).
+            const cacheUpdated = await updateWorldInfoCache(bookName, bookData);
+            if (!cacheUpdated && typeof ctx.saveWorldInfo === 'function') {
                 try { await ctx.saveWorldInfo(bookName, bookData); } catch (_) { }
             }
 
-            // Activate the book
-            if (typeof ctx.executeSlashCommandsWithOptions === 'function') {
-                await new Promise(r => setTimeout(r, 300));
-                if (typeof ctx.updateWorldInfoList === 'function') await ctx.updateWorldInfoList();
-                await ctx.executeSlashCommandsWithOptions(`/world state=on silent=true "${bookName}"`);
-            }
+            rememberCampaignBook(bookName, s);
 
             // Activate the new entry key
             const fullId = `${bookName}::${nextUid}`;
+            if (!Array.isArray(s.activeRouterKeys)) s.activeRouterKeys = [];
             if (!s.activeRouterKeys.includes(fullId)) {
                 s.activeRouterKeys.push(fullId);
             }
@@ -3291,6 +3290,16 @@ export function createPanel(dependencies) {
             if (!s.npcRelationshipValues) s.npcRelationshipValues = {};
             if (!s.npcRelationshipValues[fullId]) {
                 s.npcRelationshipValues[fullId] = { friendship: 0, affection: 0 };
+            }
+
+            void saveSettings();
+
+            // Select the book in ST so native WI (and /world-dependent paths) can see it.
+            if (typeof ctx.executeSlashCommandsWithOptions === 'function') {
+                if (typeof ctx.updateWorldInfoList === 'function') {
+                    try { await ctx.updateWorldInfoList(); } catch (_) {}
+                }
+                await ctx.executeSlashCommandsWithOptions(`/world state=on silent=true "${bookName}"`);
             }
 
             // Embed avatar as portrait (use URL directly to retain original quality and prevent settings bloat)

--- a/tests/lorebook-keyring.test.js
+++ b/tests/lorebook-keyring.test.js
@@ -4,6 +4,7 @@ import {
     buildKeyringText,
     grepLoreInBooks,
     isConcatenatedNameDump,
+    resolveBooksToScan,
 } from '../src/state/lorebook-keyring.js';
 
 const books = {
@@ -49,6 +50,30 @@ describe('lorebook keyring', () => {
     it('still searches a single phrase in labels, keys, and bodies', () => {
         const hits = grepLoreInBooks(books, 'chaplain');
         expect(hits.some(hit => hit.includes('Campaign_NPCs::0'))).toBe(true);
+    });
+});
+
+describe('resolveBooksToScan', () => {
+    it('unions campaignBooks with in-memory registry names for the prefix', () => {
+        const scanned = resolveBooksToScan(
+            ['Camp_Locations'],
+            ['Camp_Locations', 'Camp_NPCs', 'OtherChat_NPCs'],
+            'Camp',
+        );
+        expect(scanned).toEqual(expect.arrayContaining(['Camp_Locations', 'Camp_NPCs']));
+        expect(scanned).not.toContain('OtherChat_NPCs');
+    });
+
+    it('drops skeleton books and names that do not belong to the prefix', () => {
+        const scanned = resolveBooksToScan(
+            ['Camp_Skeleton', 'Camp_NPCs'],
+            ['Unrelated', 'Camp_Events'],
+            'Camp',
+            ['Camp_NPCs'],
+        );
+        expect(scanned).toEqual(expect.arrayContaining(['Camp_NPCs', 'Camp_Events']));
+        expect(scanned).not.toContain('Camp_Skeleton');
+        expect(scanned).not.toContain('Unrelated');
     });
 });
 

--- a/tests/npc-card-activation.test.js
+++ b/tests/npc-card-activation.test.js
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+const hooks = readFileSync(new URL('../narrative-hooks.js', import.meta.url), 'utf8');
+const router = readFileSync(new URL('../router.js', import.meta.url), 'utf8');
+const panel = readFileSync(new URL('../src/ui/panel/panel-builder.js', import.meta.url), 'utf8');
+
+describe('NPC card / lore activation after a newly created entry', () => {
+    it('injects agent-owned lore even when native keyword activation is on', () => {
+        const nativeGate = hooks.indexOf('if (settings.routerEnabled && !settings.routerNativeKeywordActivation && content)');
+        const agentOwned = hooks.indexOf('## ACTIVE LORE (AGENT)');
+        expect(nativeGate).toBeGreaterThanOrEqual(0);
+        expect(agentOwned).toBeGreaterThan(nativeGate);
+        const agentSlice = hooks.slice(nativeGate, agentOwned);
+        expect(agentSlice).toContain('Agent-owned entries');
+        expect(agentSlice).toContain('settings.routerNativeKeywordActivation');
+        expect(agentSlice).toContain('alreadyInjected = settings.routerNativeKeywordActivation');
+        expect(hooks).toContain('loreInjections += `\\n## ACTIVE LORE (AGENT)\\n${agentBlock.trim()}\\n`');
+    });
+
+    it('does not nest agent-owned injection inside the user-message content gate', () => {
+        const start = hooks.indexOf('let triggered = [];');
+        const agent = hooks.indexOf('const agentOwned = (settings.activeRouterKeys || [])');
+        expect(start).toBeGreaterThanOrEqual(0);
+        expect(agent).toBeGreaterThan(start);
+        const between = hooks.slice(start, agent);
+        expect(between).not.toMatch(/if \(content\) \{[\s\S]*const agentOwned/);
+        expect(between).toContain('if (settings.routerEnabled && !skipInjection)');
+    });
+
+    it('records the NPCs book on campaignBooks and persists settings after Add NPC', () => {
+        const creatorStart = panel.indexOf('const createNpcFromCharCard = async');
+        const creatorEnd = panel.indexOf('const minimalReviewNpcWithAI = async', creatorStart);
+        const creator = panel.slice(creatorStart, creatorEnd);
+        expect(creator).toContain('rememberCampaignBook(bookName, s)');
+        expect(creator).toContain('void saveSettings()');
+        expect(creator).toContain('updateWorldInfoCache(bookName, bookData)');
+        expect(creator.indexOf('rememberCampaignBook')).toBeLessThan(creator.indexOf('void saveSettings()'));
+        expect(creator.indexOf('/world state=on')).toBeGreaterThan(creator.indexOf('updateWorldInfoList'));
+        expect(creator).not.toContain('setTimeout(r, 300)');
+    });
+
+    it('writes disk-fresh lorebooks back into ST worldInfoCache on a full manifest refresh', () => {
+        expect(router).toContain('if (!skipUpdate) await updateWorldInfoCache(n, b)');
+        expect(router).toContain('export async function updateWorldInfoCache');
+        expect(router).toContain('export function rememberCampaignBook');
+        expect(router).toContain('resolveBooksToScan(knownBooks, registryNames, prefix');
+    });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

A newly built NPC could show up in the Lorebook Agent UI and in `[NPC_RELATIONS]`, then vanish from the actual GM prompt until **Activate campaign lorebooks** and **Refresh Manifest** were clicked.

That matches the reported thought trace: the model saw Friendship/Affection +0 for the character, concluded there was no NPC card, and invented looks instead.

## Causes

Several independent gaps stacked into that “refresh fixes it” loop:

1. **Agent-owned lore was gated with the keyword scanner.** `[NPC_RELATIONS]` is built from `activeRouterKeys` on every turn. The NPC **card** was injected later, inside `if (!routerNativeKeywordActivation)` and `if (content)`. Native Keyword Activation, or a user message with no extractable text (some emotes), listed the NPC in relations and skipped the card. SillyTavern native WI only injects when the book is selected and keys match — which is exactly what the Activate button does.

2. **Add NPC never recorded `campaignBooks` or persisted settings.** Boot / chat-switch `/world state=on` and the keyword scanner’s exclusive `campaignBooks` fast path never saw a book that only existed because the player used Add NPC. The 300ms delayed `/world` call could also lose the race if they sent the emote immediately.

3. **HTTP world-info writes bypass ST’s `worldInfoCache`.** The interceptor uses `ctx.loadWorldInfo()`. A full manifest refresh reads disk (`loadWorldInfoFresh`) for the UI but did not write that data back into the cache the interceptor uses.

4. **Keyword scanner treated `campaignBooks` as exclusive.** If that list was non-empty but missing the NPCs book, the scanner never opened it — even when ST’s in-memory registry already knew the book.

## Fix

- Inject agent-owned (and World Progression) lore whenever the router is on, including native keyword mode and empty user messages. Keyword scan/injection stays native-mode-gated.
- Add NPC: `rememberCampaignBook`, `updateWorldInfoCache`, `saveSettings()`, then `updateWorldInfoList` + `/world state=on` (no 300ms wait).
- Keyword / Present-Now scanners union `campaignBooks` with in-memory prefix-scoped names.
- Full manifest refresh copies disk-fresh books back into `worldInfoCache`.

## Tests

- `resolveBooksToScan` union/filter cases
- Source wiring for Add NPC persistence, interceptor gating, and cache writeback
- Full suite: 598 passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e15f7f21-8444-4bde-af0e-8f3d9f348017?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e15f7f21-8444-4bde-af0e-8f3d9f348017&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

