### PR TITLE
Release 7.95.4: keep Present Now across user turns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,11 @@ All notable changes to the **Multihog D&D Framework** will be documented in this
 
 ## [Unreleased]
 
+## [7.95.4] - 2026-08-16
+
 ### Fixed
 - **New NPC cards missing from the prompt until Activate / Refresh Manifest**: Add NPC now records the book on `campaignBooks`, writes ST's world-info cache, and persists settings so the next generate can inject the card. Agent-owned lore injects even when Native Keyword Activation is on (or the user message has no extractable text), instead of listing the NPC only in `[NPC_RELATIONS]`. The keyword scanner unions the ownership list with the in-memory registry so a newly created NPCs book is not skipped. A full manifest refresh copies disk-fresh entries back into ST's cache.
+- **Present Now empties on user turns**: the Visualization Present Now list scans only the latest narrator/assistant message. Player inputs are skipped so a turn that does not name NPCs no longer clears the tiles between replies.
 
 ## [7.95.3] - 2026-08-16
 

--- a/immersion.js
+++ b/immersion.js
@@ -59,6 +59,7 @@ export async function loadAllLocationPaths(ctx, settings) {
 
 /**
  * Present Now NPCs from a name scan of the most recent narrator output only.
+ * User messages are skipped so a player turn without NPC names does not clear the list.
  * Matches NPC entry labels (first/last name); ignores lorebook key[] keywords.
  * Independent of Lorebook Agent activeRouterKeys (avoids stale characters).
  * @param {object} settings

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
 
     "display_name": "Multihog D&D Framework",
 
-    "version": "7.95.3",
+    "version": "7.95.4",
 
     "author": "Disgusting Fatbody",
 

--- a/router.js
+++ b/router.js
@@ -21,6 +21,7 @@ import {
     trimLoreHistoryForRollback,
 } from './src/state/lorebook-history.js';
 import { buildKeyringText, grepLoreInBooks, isSkeletonBookName, resolveBooksToScan } from './src/state/lorebook-keyring.js';
+import { findMostRecentNarratorMessage } from './src/state/present-now.js';
 import {
     applyDungeonMapTransaction,
     attachDungeonMapToLocationEntry,
@@ -3966,33 +3967,29 @@ function getRecentlyRecordedNpcIds(settings) {
 }
 
 /**
- * Most recent single assistant/narrator message only (not the whole multi-message turn block).
+ * Most recent single assistant/narrator message only (not the whole multi-message
+ * turn block, and never a user input — Present Now must not empty between replies).
  * @param {boolean} [includeHidden]
  * @returns {string}
  */
 function getMostRecentNarrativeText(includeHidden = false) {
     const { chat } = SillyTavern.getContext();
-    if (!chat?.length) return '';
-    for (let i = chat.length - 1; i >= 0; i--) {
-        const msg = chat[i];
-        if (msg.is_user) break;
-        if (msg.is_system) continue;
-        if (!includeHidden && /** @type {any} */ (msg).is_hidden) continue;
-        if (msg.extra?.['summary'] || msg.extra?.['is_summary'] || msg.extra?.['summary_data']) continue;
-        const mes = cleanMessageContent(msg);
-        if (!mes) continue;
-        if (mes.startsWith('[Summary') || mes.startsWith('(Summary') || mes.includes('Summary of past events:')) continue;
-        return mes;
-    }
-    return '';
+    const msg = findMostRecentNarratorMessage(chat, { includeHidden });
+    if (!msg) return '';
+    const mes = cleanMessageContent(msg);
+    if (!mes) return '';
+    if (mes.startsWith('[Summary') || mes.startsWith('(Summary') || mes.includes('Summary of past events:')) return '';
+    return mes;
 }
 
 /**
  * Present-Now name scanner — separate from the Lorebook Agent keyword scanner.
  * Scans ONLY the latest single narrator message for NPC names (entry comment/label).
- * First/last name tokens are enough for established NPCs; NPCs the agent just
- * recorded this pass require a full-name match so loose tokens/keys do not
- * instantly populate Present Now. Lorebook key[] arrays are never scanned.
+ * User messages are never scanned: a player turn without explicit NPC names must
+ * not clear Present Now. First/last name tokens are enough for established NPCs;
+ * NPCs the agent just recorded this pass require a full-name match so loose
+ * tokens/keys do not instantly populate Present Now. Lorebook key[] arrays are
+ * never scanned.
  *
  * Call immediately before location scene image generation (and when building Present Now UI).
  *

--- a/src/state/present-now.js
+++ b/src/state/present-now.js
@@ -1,0 +1,21 @@
+/**
+ * Latest narrator/assistant chat message, walking newest-first.
+ * User and system messages are skipped so Present Now stays on the last
+ * narrator output instead of emptying when the player sends a turn.
+ *
+ * @param {Array<{ is_user?: boolean, is_system?: boolean, is_hidden?: boolean, extra?: object }>} chat
+ * @param {{ includeHidden?: boolean }} [opts]
+ * @returns {object|null}
+ */
+export function findMostRecentNarratorMessage(chat, { includeHidden = false } = {}) {
+    if (!Array.isArray(chat) || chat.length === 0) return null;
+    for (let i = chat.length - 1; i >= 0; i--) {
+        const msg = chat[i];
+        if (!msg || msg.is_user || msg.is_system) continue;
+        if (!includeHidden && msg.is_hidden) continue;
+        const extra = msg.extra || {};
+        if (extra.summary || extra.is_summary || extra.summary_data) continue;
+        return msg;
+    }
+    return null;
+}

--- a/tests/present-now.test.js
+++ b/tests/present-now.test.js
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { findMostRecentNarratorMessage } from '../src/state/present-now.js';
+
+describe('findMostRecentNarratorMessage', () => {
+    it('skips a trailing user message and keeps the previous narrator output', () => {
+        const chat = [
+            { is_user: false, mes: 'Megumi waits in the office.' },
+            { is_user: true, mes: '*heads to the guidance office*' },
+        ];
+        expect(findMostRecentNarratorMessage(chat)?.mes).toBe('Megumi waits in the office.');
+    });
+
+    it('returns the latest assistant message when that is the tail', () => {
+        const chat = [
+            { is_user: true, mes: 'I look around.' },
+            { is_user: false, mes: 'Darukawa Megumi looks up from her desk.' },
+        ];
+        expect(findMostRecentNarratorMessage(chat)?.mes).toBe('Darukawa Megumi looks up from her desk.');
+    });
+
+    it('skips system, hidden, and summary messages', () => {
+        const chat = [
+            { is_user: false, mes: 'Keep this narrator beat.' },
+            { is_system: true, mes: 'system note' },
+            { is_user: false, is_hidden: true, mes: 'hidden swipe' },
+            { is_user: false, extra: { is_summary: true }, mes: 'Summary of past events.' },
+            { is_user: true, mes: 'continue' },
+        ];
+        expect(findMostRecentNarratorMessage(chat)?.mes).toBe('Keep this narrator beat.');
+    });
+
+    it('returns null when the chat has no narrator output', () => {
+        expect(findMostRecentNarratorMessage([{ is_user: true, mes: 'hello' }])).toBeNull();
+        expect(findMostRecentNarratorMessage([])).toBeNull();
+        expect(findMostRecentNarratorMessage(null)).toBeNull();
+    });
+});
+
+describe('Present Now scanner wiring', () => {
+    it('reads narrator text via findMostRecentNarratorMessage and does not stop at user turns', () => {
+        const router = readFileSync(new URL('../router.js', import.meta.url), 'utf8');
+        expect(router).toContain("import { findMostRecentNarratorMessage } from './src/state/present-now.js'");
+        expect(router).toContain('findMostRecentNarratorMessage(chat, { includeHidden })');
+        expect(router).not.toContain('if (msg.is_user) break');
+        expect(router).toContain('User messages are never scanned');
+    });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Version

**7.95.3 → 7.95.4** in `manifest.json` so SillyTavern auto-update can pick this up. That bump also covers the merged NPC-card injection fix from #41, which shipped without a version change.

## Present Now

The Visualization **Present Now** list was walking chat newest-first and **stopping at the first user message**. After the player sent a turn, that was the tail of the chat, the scan returned empty, and the tiles cleared until the next assistant reply.

User messages are now skipped. Present Now stays on the latest narrator/assistant output.

## Also in 7.95.4

- The #41 NPC-card injection / `campaignBooks` / cache fixes, now versioned so clients can auto-update.

## Tests

- `findMostRecentNarratorMessage` skips trailing user/system/hidden/summary messages
- Full suite: 603 passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e15f7f21-8444-4bde-af0e-8f3d9f348017?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e15f7f21-8444-4bde-af0e-8f3d9f348017&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

