### PR TITLE
Release 8.1.3: keep Quick Prompt Main backup durable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the **Multihog D&D Framework** will be documented in this
 
 ## [Unreleased]
 
+## [8.1.3] - 2026-08-18
+
+### Fixed
+- **Main prompt backup**: the original Quick Prompt Main is now snapshotted from Prompt Manager (not only an empty/unhydrated textarea) *before* the framework overwrites it, then mirrored to a browser-local backup that cannot be cancelled by a settings.json save or wiped by turning the tracker/extension off. Disable (⏻) restores that copy even when Quick Prompts is closed, and a later re-enable will not replace a real user backup with the D&D narrator prompt or an empty string.
+
 ## [8.1.2] - 2026-08-18
 
 ### Changed

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 import { EXAMPLES, COLOR_EXAMPLES, DEFAULT_STOCK_PROMPTS, RT_PROMPTS, BLOCK_ICONS, BLOCK_ORDER, PAGE_SIZE, NO_PAGINATE, buildOnboardingXpHint, buildOnboardingTimeHint, buildStartingGearHint, buildOnboardingActiveBlocks, buildCombatAndSkillScalingHint, resolveTimePromptKey, resolveTimePromptDisplayTag, buildCyoaPrompt, DEFAULT_CYOA_SLOTS, refreshCyoaConfigToShipped, formatTimeOfDay } from './constants.js';
-import { MODULE_NAME, DEFAULT_MODULES, MODULE_BOOK_CATEGORY, FULL_REVIEW_STATE_SYSTEM_PROMPT, FULL_REVIEW_USER_PROMPT_SUFFIX, getSettings, getBarBackground, migrateCustomFields, saveChatState, getActiveChatId, writeModuleSchemaBackup, getPendingModuleSchemaBackup, applyModuleSchemaBackup, applyDeletedCustomTagTombstones, recordDeletedCustomTags, clearDeletedCustomTagTombstones, saveProfile, deleteProfile, getEffectiveRouterCampaignPrefix, sanitizeCampaignPrefixString, buildNpcInstruction, LOREBOOK_FULL_AUDIT_INSTRUCTION, loadStockPromptsFromProfile, getNpcRelationshipMax, getNpcRelationshipMaxDefault, clampRelationshipValue, relationshipBarPct, getFriendshipTier, getAffectionTier, getRelTierBadgeStyle, getRelTierDetailedStyle, getRelTierDetailedLabelStyle, applyRelTierBadgeElement, sanitizeRouterState, rebuildAllModuleInstructions, adjustAllStoredTemplatesForTimeFormat, DEFAULT_NPC_SECTIONS, DEFAULT_PC_SECTIONS, computeBundledPromptsFingerprint, computeBundledPromptsFingerprintForSnapshot, normalizeBundledPromptsSnapshot, buildBundledPromptsSnapshot, getSnapshotCategoryBlocks, getPromptCategoryImpactBadge, PROMPT_DEFAULTS_CATEGORIES, PROMPT_DEFAULTS_CATEGORY_LABELS, getDefaultPortraitLocationSystemPrompt, isShippedPortraitLocationSystemPrompt, applyFactoryReset, clearExtensionLocalStorageUiState, stripChatStateGlobalUiPrefs, buildStateTrackerRelationshipCommandInstruction, extractStateTrackerRelationshipCommands, getRelationshipUpdateMode, RELATIONSHIP_UPDATE_MODES, resetLorebookPromptTemplates, writeCriticalSettingsBackup, stampCriticalSettingsSynced, applyCriticalSettingsBackup } from './state-manager.js';
+import { MODULE_NAME, DEFAULT_MODULES, MODULE_BOOK_CATEGORY, FULL_REVIEW_STATE_SYSTEM_PROMPT, FULL_REVIEW_USER_PROMPT_SUFFIX, getSettings, getBarBackground, migrateCustomFields, saveChatState, getActiveChatId, writeModuleSchemaBackup, getPendingModuleSchemaBackup, applyModuleSchemaBackup, applyDeletedCustomTagTombstones, recordDeletedCustomTags, clearDeletedCustomTagTombstones, saveProfile, deleteProfile, getEffectiveRouterCampaignPrefix, sanitizeCampaignPrefixString, buildNpcInstruction, LOREBOOK_FULL_AUDIT_INSTRUCTION, loadStockPromptsFromProfile, getNpcRelationshipMax, getNpcRelationshipMaxDefault, clampRelationshipValue, relationshipBarPct, getFriendshipTier, getAffectionTier, getRelTierBadgeStyle, getRelTierDetailedStyle, getRelTierDetailedLabelStyle, applyRelTierBadgeElement, sanitizeRouterState, rebuildAllModuleInstructions, adjustAllStoredTemplatesForTimeFormat, DEFAULT_NPC_SECTIONS, DEFAULT_PC_SECTIONS, computeBundledPromptsFingerprint, computeBundledPromptsFingerprintForSnapshot, normalizeBundledPromptsSnapshot, buildBundledPromptsSnapshot, getSnapshotCategoryBlocks, getPromptCategoryImpactBadge, PROMPT_DEFAULTS_CATEGORIES, PROMPT_DEFAULTS_CATEGORY_LABELS, getDefaultPortraitLocationSystemPrompt, isShippedPortraitLocationSystemPrompt, applyFactoryReset, clearExtensionLocalStorageUiState, stripChatStateGlobalUiPrefs, buildStateTrackerRelationshipCommandInstruction, extractStateTrackerRelationshipCommands, getRelationshipUpdateMode, RELATIONSHIP_UPDATE_MODES, resetLorebookPromptTemplates, writeCriticalSettingsBackup, stampCriticalSettingsSynced, applyCriticalSettingsBackup, isMainSyspromptBackupEnabled, captureMainSyspromptBackup, restoreMainSyspromptStash, hydrateMainSyspromptBackup, getEffectiveBackupText, getLiveMainSyspromptText, setLiveMainSyspromptText, maybeRestoreMainIfTrackerDisabled, isMainSyspromptSourceReady } from './state-manager.js';
 import { snapshotChatSetup, chatSetupsMatch, syncChatSetupCatalogs, removeChatSetupCatalogEntries, clearChatBoundActivations } from './src/state/chat-setup.js';
 import { buildDirectPromptSystemPrompt, DIRECT_PROMPT_SYSTEM_MODES } from './src/state/direct-prompt-system.js';
 import { diffTextLines, diffHasChanges } from './prompt-diff.js';
@@ -4657,42 +4657,16 @@ export async function fetchBaseSyspromptRaw(settingsOverride = null) {
     return content || '';
 }
 
-function getMainSyspromptTextarea() {
-    return /** @type {HTMLTextAreaElement|null} */ (document.getElementById('main_prompt_quick_edit_textarea'));
-}
-
-function isMainSyspromptBackupEnabled(settings) {
-    return settings.mainSyspromptBackupEnabled !== false;
-}
-
-/** Snapshot Quick Prompt Main before the framework overwrites it (once per tracker-on period). */
-function armMainSyspromptStash(settings, force = false, { manual = false } = {}) {
-    if (!isMainSyspromptBackupEnabled(settings)) return false;
-    if (!manual && (settings.customSysprompt || !settings.enabled)) return false;
-    if (settings.syspromptStashArmed && !force) return true;
-    const ta = getMainSyspromptTextarea();
-    if (!ta) return false;
-    settings.stashedMainSysprompt = ta.value;
-    settings.syspromptStashArmed = true;
-    saveSettings();
+function persistMainSyspromptBackupIfChanged(result, settings) {
+    if (result?.changed) saveSettings(true);
     updateMainSyspromptBackupStatusUi(settings);
-    return true;
 }
 
-/** Restore stashed Quick Prompt Main when the tracker is turned off (or manually from settings). */
-function restoreMainSyspromptStash(settings, { manual = false } = {}) {
-    if (!isMainSyspromptBackupEnabled(settings) || !settings.syspromptStashArmed) return false;
-    if (!manual && settings.customSysprompt) return false;
-    const ta = getMainSyspromptTextarea();
-    if (!ta) return false;
-    ta.value = settings.stashedMainSysprompt ?? '';
-    ta.dispatchEvent(new Event('blur', { bubbles: true }));
-    if (!manual) {
-        settings.syspromptStashArmed = false;
-        saveSettings();
-    }
+function restoreTrackedMainSysprompt(settings, { manual = false } = {}) {
+    const restored = restoreMainSyspromptStash(settings, { manual });
+    if (restored) saveSettings(true);
     updateMainSyspromptBackupStatusUi(settings);
-    return true;
+    return restored;
 }
 
 function updateMainSyspromptBackupStatusUi(settings = getSettings()) {
@@ -4712,14 +4686,13 @@ function updateMainSyspromptBackupStatusUi(settings = getSettings()) {
         statusEl.textContent = 'Backup is disabled — enable above to save or restore.';
         return;
     }
-    if (!settings.syspromptStashArmed) {
-        statusEl.textContent = 'No backup saved yet. It is created automatically before the framework overwrites Main, or use Save above.';
+    hydrateMainSyspromptBackup(settings);
+    const backupLen = getEffectiveBackupText(settings).length;
+    if (!backupLen) {
+        statusEl.textContent = 'No backup saved yet. It is created automatically before the framework overwrites Main, and kept in this browser even if the tracker or extension is turned off.';
         return;
     }
-    const len = (settings.stashedMainSysprompt ?? '').length;
-    statusEl.textContent = len
-        ? `Backup saved (${len.toLocaleString()} characters).`
-        : 'Backup saved (empty Main prompt).';
+    statusEl.textContent = `Backup saved (${backupLen.toLocaleString()} characters). Kept if you disable the tracker or the extension.`;
 }
 
 function syncMainSyspromptBackupControlsUi() {
@@ -4731,16 +4704,16 @@ async function handleTrackerEnabledChange(settings, enabled) {
     saveSettings();
     updatePanelStatus();
     if (settings.enabled) {
-        armMainSyspromptStash(settings, true);
         await autoApplySysprompt(true);
     } else {
-        restoreMainSyspromptStash(settings);
+        restoreTrackedMainSysprompt(settings);
         void resetCombatProfileOverride(settings);
     }
 }
 
 let _autoApplyTimer = null;
 let _stashDeferCount = 0;
+let _restoreDeferCount = 0;
 const MAX_STASH_DEFER = 25;
 let _lastDynamicRngCombatState = null;
 
@@ -4752,27 +4725,33 @@ export async function autoApplySysprompt(force = false) {
     if (s.customSysprompt) return;
     if (!force && !s.enabled) return;
 
+    const content = await fetchBaseSyspromptRaw(s);
+    if (!content) return;
+
+    const built = buildSysprompt(content);
+
     if (s.enabled && isMainSyspromptBackupEnabled(s)) {
-        const armed = armMainSyspromptStash(s);
-        if (!armed && !s.syspromptStashArmed) {
+        const result = captureMainSyspromptBackup(s, { builtFrameworkText: built });
+        persistMainSyspromptBackupIfChanged(result, s);
+        if (result.shouldDefer) {
             if (_stashDeferCount < MAX_STASH_DEFER) {
                 _stashDeferCount++;
                 scheduleAutoApply();
                 return;
             }
+            if (!getEffectiveBackupText(s).trim()) {
+                console.warn('[RPG Tracker] Refusing to overwrite Quick Prompt Main: backup source is not ready and no durable backup exists.');
+                return;
+            }
+        }
+        if (!result.ok && !getEffectiveBackupText(s).trim()) {
+            console.warn('[RPG Tracker] Refusing to overwrite Quick Prompt Main until a user backup can be saved.');
+            return;
         }
     }
     _stashDeferCount = 0;
 
-    const content = await fetchBaseSyspromptRaw(s);
-    if (!content) return;
-
-    const built = buildSysprompt(content);
-    const mainTextarea = /** @type {HTMLTextAreaElement|null} */ (document.getElementById('main_prompt_quick_edit_textarea'));
-    if (mainTextarea) {
-        mainTextarea.value = built;
-        mainTextarea.dispatchEvent(new Event('blur', { bubbles: true }));
-    }
+    setLiveMainSyspromptText(built);
 }
 
 /**
@@ -4810,6 +4789,21 @@ function scheduleAutoApply() {
     if (!s.enabled || s.customSysprompt) return;
     if (_autoApplyTimer) clearTimeout(_autoApplyTimer);
     _autoApplyTimer = setTimeout(() => { _autoApplyTimer = null; autoApplySysprompt(); }, 400);
+}
+
+function scheduleDisabledTrackerMainRestore() {
+    const s = getSettings();
+    if (s.enabled || s.customSysprompt) return;
+    if (maybeRestoreMainIfTrackerDisabled(s)) {
+        saveSettings(true);
+        updateMainSyspromptBackupStatusUi(s);
+        _restoreDeferCount = 0;
+        return;
+    }
+    if (!isMainSyspromptSourceReady() && _restoreDeferCount < MAX_STASH_DEFER) {
+        _restoreDeferCount++;
+        setTimeout(scheduleDisabledTrackerMainRestore, 400);
+    }
 }
 
 /**
@@ -5278,6 +5272,9 @@ function organizeConnectionSettingsUI() {
         // Disk settings.json saves (~12MB) are often cancelled when reloading after code edits;
         // this sync localStorage WAL restores the last intentional change.
         if (applyCriticalSettingsBackup(earlySettings)) {
+            void saveSettings(true);
+        }
+        if (hydrateMainSyspromptBackup(earlySettings)) {
             void saveSettings(true);
         }
     }
@@ -5931,8 +5928,7 @@ function organizeConnectionSettingsUI() {
                             // Wait a short moment for the UI to be fully drawn
                             await sleepMs(500);
 
-                            const mainTa = getMainSyspromptTextarea();
-                            const mainSyspromptText = mainTa ? mainTa.value : '';
+                            const mainSyspromptText = getLiveMainSyspromptText();
                             const changedCats = getChangedPromptDefaultCategories(storedSnapshot, currentSnapshot);
                             const hasSnapshot = !!storedSnapshot;
                             const changedLabels = [...changedCats]
@@ -6326,10 +6322,14 @@ function organizeConnectionSettingsUI() {
             if (!isMainSyspromptBackupEnabled(fresh)) {
                 return toastr['warning']('Main prompt backup is disabled. Enable it above first.', 'RPG Tracker');
             }
-            if (armMainSyspromptStash(fresh, true, { manual: true })) {
+            const result = captureMainSyspromptBackup(fresh, { manual: true });
+            persistMainSyspromptBackupIfChanged(result, fresh);
+            if (result.changed || result.reason === 'kept' || result.reason === 'captured') {
                 toastr['success']('Current Quick Prompt Main saved to backup.', 'RPG Tracker');
-            } else if (!getMainSyspromptTextarea()) {
-                toastr['warning']('Quick Prompt Main is not open — open Quick Prompt first, then try again.', 'RPG Tracker');
+            } else if (result.reason === 'empty') {
+                toastr['warning']('Current Main is empty — refusing to overwrite a saved backup with nothing.', 'RPG Tracker');
+            } else if (result.reason === 'already-framework') {
+                toastr['warning']('Current Main looks like the framework prompt, so the existing backup was left unchanged.', 'RPG Tracker');
             } else {
                 toastr['error']('Could not save backup.', 'RPG Tracker');
             }
@@ -6340,16 +6340,14 @@ function organizeConnectionSettingsUI() {
             if (!isMainSyspromptBackupEnabled(fresh)) {
                 return toastr['warning']('Main prompt backup is disabled. Enable it above first.', 'RPG Tracker');
             }
-            if (!fresh.syspromptStashArmed) {
+            if (!getEffectiveBackupText(fresh).trim()) {
                 return toastr['info']('No backup saved yet. Use Save current Main to backup first.', 'RPG Tracker');
             }
-            if (restoreMainSyspromptStash(fresh, { manual: true })) {
+            if (restoreTrackedMainSysprompt(fresh, { manual: true })) {
                 const note = fresh.enabled && !fresh.customSysprompt
                     ? ' Click ⏻ on the tracker panel to keep it — the framework may overwrite Main again while the tracker is on.'
                     : '';
                 toastr['success'](`Backed-up Main prompt restored.${note}`, 'RPG Tracker');
-            } else if (!getMainSyspromptTextarea()) {
-                toastr['warning']('Quick Prompt Main is not open — open Quick Prompt first, then try again.', 'RPG Tracker');
             } else {
                 toastr['error']('Could not restore backup.', 'RPG Tracker');
             }
@@ -11560,7 +11558,9 @@ RULES:
     // Fresh installs default to tracker on — schedule first apply so Main is stashed then overwritten.
     {
         const s = getSettings();
+        hydrateMainSyspromptBackup(s);
         if (s.enabled && !s.customSysprompt) scheduleAutoApply();
+        else scheduleDisabledTrackerMainRestore();
     }
 
     // Add wand button to toggle panel visibility

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
 
     "display_name": "Multihog D&D Framework",
 
-    "version": "8.1.2",
+    "version": "8.1.3",
 
     "author": "Disgusting Fatbody",
 

--- a/settings.html
+++ b/settings.html
@@ -48,13 +48,13 @@
                         <!-- MAIN PROMPT BACKUP -->
                         <small style="display: block; margin-top: 10px; margin-bottom: 2px; font-weight: bold; opacity: 0.65; text-transform: uppercase; font-size: 0.7em; letter-spacing: 0.4px;">Main Prompt Backup</small>
                         <div style="font-size: 0.78em; opacity: 0.65; line-height: 1.4; padding: 0 4px; margin-bottom: 6px;">
-                            When the State Tracker is on (and Custom Sysprompt Mode is off), the framework writes its system prompt to <b>Quick Prompt → Main</b>, replacing whatever was there. This backup saves that previous Main text so you can get it back — automatically before the first overwrite, and again when you disable the tracker with the <b>⏻</b> button on the tracker panel header (or by unchecking <b>Enable State Tracker</b> in settings). To jump back to your normal, non-D&amp;D RP, click <b>⏻</b> on the panel — your original Main prompt is restored right away, no profile switching. Use the buttons below anytime to refresh the saved copy (for example after editing Main yourself).
+                        When the State Tracker is on (and Custom Sysprompt Mode is off), the framework writes its system prompt to <b>Quick Prompt → Main</b>, replacing whatever was there. Your previous Main text is auto-saved <b>before</b> that overwrite, in this browser, independently of settings.json. The copy is kept when you click <b>⏻</b>, uncheck <b>Enable State Tracker</b>, disable the extension, or reload — it is not deleted just because the tracker is off. To jump back to your normal, non-D&amp;D RP, click <b>⏻</b> on the panel. Use the buttons below anytime to refresh the saved copy after editing Main yourself (while the tracker is off, or in Custom Sysprompt Mode).
                         </div>
                         <label class="checkbox_label" style="padding-left: 4px;">
                             <input id="rpg_main_sysprompt_backup_enabled" type="checkbox" />
                             <span>Enable Main prompt backup &amp; restore</span>
                             <i class="fa-solid fa-circle-question interactable"
-                                title="On by default. When enabled, your Quick Prompt Main text is snapshotted before the framework overwrites it and restored when you click the ⏻ button on the tracker panel (or uncheck Enable State Tracker) — so you can return to normal, non-D&amp;D RP that way. You can also save or restore manually with the buttons below."></i>
+                                title="On by default. Your Quick Prompt Main is snapshotted before the framework overwrites it and stored in this browser so it cannot be wiped by a cancelled settings save, a tracker ⏻ toggle, or temporarily disabling the extension. Restore happens when you click ⏻ (or uncheck Enable State Tracker). You can also save or restore manually with the buttons below."></i>
                         </label>
                         <div id="rpg_main_sysprompt_backup_controls" class="flex-container flexFlowColumn gap-1" style="padding-left: 4px; margin-top: 4px;">
                             <div class="flex-container gap-1" style="width: 100%;">
@@ -783,7 +783,7 @@
                         <input id="rpg_tracker_enabled" type="checkbox" />
                         <span>Enable State Tracker</span>
                         <i class="fa-solid fa-circle-question interactable"
-                            title="When enabled (and Custom Sysprompt Mode is off), the framework system prompt is written to Quick Prompt Main. Your previous Main prompt is backed up automatically before the first overwrite and restored when you click the ⏻ button on the tracker panel (or uncheck this box) — so you can quickly return to normal, non-D&amp;D RP without changing profiles."></i>
+                            title="When enabled (and Custom Sysprompt Mode is off), the framework system prompt is written to Quick Prompt Main. Your previous Main prompt is backed up first (browser-local, kept even if you disable the tracker or the extension) and restored when you click the ⏻ button on the tracker panel (or uncheck this box)."></i>
                     </label>
 
                     <label class="checkbox_label" style="margin-bottom: 8px;" title="Forces the State Model to output the COMPLETE, verified state for every enabled module on every pass, instead of only the changed sections. Trades tokens/latency for reliability — recommended for weaker/local models that struggle to keep delta-tracked state consistent. While enabled, the Core Prompt and User Prompt Suffix (further below) are temporarily replaced by built-in Full Review versions; your custom edits are preserved and restored when you turn this off.">

--- a/src/state/defaults.js
+++ b/src/state/defaults.js
@@ -12,6 +12,7 @@ import { DEFAULT_MAP_UPDATER_SYSTEM_PROMPT } from '../../map-updater-prompt.js';
 import { DEFAULT_MAP_EVOLUTION_SYSTEM_PROMPT } from '../../map-evolution-prompt.js';
 import { DEFAULT_MAP_EVOLUTION_COMPRESS_SYSTEM_PROMPT } from '../../map-evolution-compress-prompt.js';
 import { DEFAULT_WORLD_PROGRESSION_SYSTEM_PROMPT } from '../../world-progression-prompt.js';
+import { MAIN_SYSPROMPT_BACKUP_KEY } from './main-sysprompt-backup.js';
 import {
     DEFAULT_ROUTER_AUTO_PASS_RESTRICTION,
     DEFAULT_ROUTER_COMBAT_PROFILE_GUIDANCE_AGENT,
@@ -187,6 +188,10 @@ export function buildDefaultSettings() {
         stashedMainSysprompt: '',
 
         syspromptStashArmed: false,
+
+        /** Timestamp of the last durable Main-prompt localStorage backup write. */
+
+        mainSyspromptBackupTs: 0,
 
         rngEnabled: true,
 
@@ -1542,7 +1547,9 @@ export function clearExtensionLocalStorageUiState() {
 
         const key = localStorage.key(i);
 
-        if (key?.startsWith('rpg_tracker_')) keys.push(key);
+        // The user's original Quick Prompt Main is not UI chrome — keep it across
+        // factory reset so disabling/resetting the extension cannot delete it.
+        if (key?.startsWith('rpg_tracker_') && key !== MAIN_SYSPROMPT_BACKUP_KEY) keys.push(key);
 
     }
 

--- a/src/state/main-sysprompt-backup.js
+++ b/src/state/main-sysprompt-backup.js
@@ -1,0 +1,374 @@
+/**
+ * Durable backup of SillyTavern Quick Prompt Main.
+ *
+ * The framework overwrites Main with its narrator prompt while the tracker is on.
+ * That snapshot must be taken *before* the overwrite, and it must survive:
+ * cancelled settings.json saves, tracker ⏻ disable, extension disable/reload,
+ * and empty-textarea races while Prompt Manager is still hydrating.
+ *
+ * Storage is dual-write: extension settings (disk) + a sync localStorage WAL.
+ * localStorage cannot be cancelled by a reload, so it is the copy that is
+ * never discarded once a non-empty user prompt has been captured.
+ */
+
+export const MAIN_SYSPROMPT_BACKUP_KEY = 'rpg_tracker_main_sysprompt_backup';
+
+const MAIN_TEXTAREA_ID = 'main_prompt_quick_edit_textarea';
+
+/** Markers present in every shipped Multihog narrator prompt (normal + legacy). */
+const FRAMEWORK_SYSPROMPT_MARKERS = [
+    'DM/World Simulator for a D&D-style TTRPG',
+    '<rng_system>',
+];
+
+/**
+ * @param {Record<string, any>|null|undefined} settings
+ * @returns {boolean}
+ */
+export function isMainSyspromptBackupEnabled(settings) {
+    return !settings || settings.mainSyspromptBackupEnabled !== false;
+}
+
+/**
+ * @returns {HTMLTextAreaElement|null}
+ */
+export function getMainSyspromptTextarea() {
+    if (typeof document === 'undefined' || typeof document.getElementById !== 'function') return null;
+    return /** @type {HTMLTextAreaElement|null} */ (document.getElementById(MAIN_TEXTAREA_ID));
+}
+
+/**
+ * @returns {Record<string, any>|null}
+ */
+export function getChatCompletionSettings() {
+    try {
+        const ctx = globalThis.SillyTavern?.getContext?.();
+        if (ctx?.chatCompletionSettings && typeof ctx.chatCompletionSettings === 'object') {
+            return ctx.chatCompletionSettings;
+        }
+    } catch {
+        /* host not ready */
+    }
+    const fallback = globalThis.oai_settings;
+    return fallback && typeof fallback === 'object' ? fallback : null;
+}
+
+/**
+ * True when we can read the live Main prompt from the textarea or Prompt Manager store.
+ * An empty value on a ready source means the user really has an empty Main.
+ * @returns {boolean}
+ */
+export function isMainSyspromptSourceReady() {
+    if (getMainSyspromptTextarea()) return true;
+    const oai = getChatCompletionSettings();
+    if (!oai) return false;
+    if (Array.isArray(oai.prompts)) return true;
+    return typeof oai.main_prompt === 'string';
+}
+
+/**
+ * @param {Record<string, any>|null} oai
+ * @returns {string}
+ */
+function readPromptManagerMain(oai) {
+    if (!oai || typeof oai !== 'object') return '';
+    if (Array.isArray(oai.prompts)) {
+        const main = oai.prompts.find((item) => item && item.identifier === 'main');
+        if (main && typeof main.content === 'string') return main.content;
+    }
+    if (typeof oai.main_prompt === 'string') return oai.main_prompt;
+    return '';
+}
+
+/**
+ * Live Quick Prompt Main: prefer a non-empty textarea (user may be editing),
+ * otherwise Prompt Manager / oai_settings so we do not snapshot an unhydrated empty box.
+ * @returns {string}
+ */
+export function getLiveMainSyspromptText() {
+    const ta = getMainSyspromptTextarea();
+    const fromTa = ta ? String(ta.value ?? '') : '';
+    const fromPm = readPromptManagerMain(getChatCompletionSettings());
+    if (fromTa.trim()) return fromTa;
+    if (fromPm.trim()) return fromPm;
+    return fromTa || fromPm || '';
+}
+
+/**
+ * Write Main both to the Quick Edit textarea (when present) and to Prompt Manager
+ * so restore works even if the Quick Prompts drawer is not in the DOM.
+ * @param {string} text
+ * @returns {boolean} true if any store accepted the write
+ */
+export function setLiveMainSyspromptText(text) {
+    const value = String(text ?? '');
+    let wrote = false;
+    const oai = getChatCompletionSettings();
+    if (oai) {
+        if (Array.isArray(oai.prompts)) {
+            const main = oai.prompts.find((item) => item && item.identifier === 'main');
+            if (main && typeof main === 'object') {
+                main.content = value;
+                wrote = true;
+            }
+        }
+        if (Object.prototype.hasOwnProperty.call(oai, 'main_prompt') || !wrote) {
+            oai.main_prompt = value;
+            wrote = true;
+        }
+    }
+    const ta = getMainSyspromptTextarea();
+    if (ta) {
+        ta.value = value;
+        try {
+            ta.dispatchEvent(new Event('input', { bubbles: true }));
+            ta.dispatchEvent(new Event('blur', { bubbles: true }));
+        } catch {
+            /* jsdom/event stubs */
+        }
+        wrote = true;
+    }
+    try {
+        globalThis.SillyTavern?.getContext?.()?.saveSettingsDebounced?.();
+    } catch {
+        /* non-fatal */
+    }
+    return wrote;
+}
+
+/**
+ * @param {string} text
+ * @param {string} [builtFrameworkText]
+ * @returns {boolean}
+ */
+export function looksLikeFrameworkSysprompt(text, builtFrameworkText = '') {
+    const t = String(text ?? '').trim();
+    if (!t) return false;
+    const built = String(builtFrameworkText ?? '').trim();
+    if (built && t === built) return true;
+    return FRAMEWORK_SYSPROMPT_MARKERS.every((marker) => t.includes(marker));
+}
+
+/**
+ * @returns {{ ts: number, text: string }|null}
+ */
+export function readDurableMainSyspromptBackup() {
+    try {
+        const raw = localStorage.getItem(MAIN_SYSPROMPT_BACKUP_KEY);
+        if (!raw) return null;
+        const parsed = JSON.parse(raw);
+        if (!parsed || typeof parsed !== 'object') return null;
+        if (typeof parsed.text !== 'string') return null;
+        const ts = Number(parsed.ts);
+        return { ts: Number.isFinite(ts) ? ts : 0, text: parsed.text };
+    } catch (err) {
+        console.warn('[RPG Tracker] Main sysprompt backup read failed:', err);
+        return null;
+    }
+}
+
+/**
+ * Mirror the backup into localStorage. Never replaces a non-empty copy with empty.
+ * @param {string} text
+ * @returns {number} backup timestamp
+ */
+export function writeDurableMainSyspromptBackup(text) {
+    const next = String(text ?? '');
+    const existing = readDurableMainSyspromptBackup();
+    if (!next.trim()) {
+        if (existing?.text?.trim()) {
+            console.warn('[RPG Tracker] Refusing to erase a non-empty Main prompt backup from localStorage.');
+            return existing.ts || Date.now();
+        }
+        return existing?.ts || 0;
+    }
+    const ts = Date.now();
+    try {
+        localStorage.setItem(MAIN_SYSPROMPT_BACKUP_KEY, JSON.stringify({ ts, text: next }));
+    } catch (err) {
+        console.warn('[RPG Tracker] Main sysprompt backup write failed:', err);
+    }
+    return ts;
+}
+
+/**
+ * Prefer a real user prompt over an empty or framework-shaped copy.
+ * When both copies are real user prompts, prefer the newer timestamp.
+ * @param {string} settingsText
+ * @param {{ ts?: number, text?: string }|null} durable
+ * @param {number} [settingsTs]
+ * @returns {string}
+ */
+export function pickPreferredBackupText(settingsText, durable, settingsTs = 0) {
+    const fromSettings = String(settingsText ?? '');
+    const fromDurable = durable && typeof durable.text === 'string' ? durable.text : '';
+    if (fromSettings.trim() && !fromDurable.trim()) return fromSettings;
+    if (fromDurable.trim() && !fromSettings.trim()) return fromDurable;
+    if (!fromSettings.trim() && !fromDurable.trim()) return '';
+    if (fromSettings === fromDurable) return fromSettings;
+
+    const settingsIsFw = looksLikeFrameworkSysprompt(fromSettings);
+    const durableIsFw = looksLikeFrameworkSysprompt(fromDurable);
+    if (settingsIsFw && !durableIsFw) return fromDurable;
+    if (durableIsFw && !settingsIsFw) return fromSettings;
+    const aTs = Number(settingsTs) || 0;
+    const bTs = Number(durable?.ts) || 0;
+    if (aTs !== bTs) return bTs > aTs ? fromDurable : fromSettings;
+    if (fromSettings.length !== fromDurable.length) {
+        return fromSettings.length >= fromDurable.length ? fromSettings : fromDurable;
+    }
+    return fromDurable || fromSettings;
+}
+
+/**
+ * Heal settings from localStorage (or vice versa) and return the kept text.
+ * @param {Record<string, any>|null|undefined} settings
+ * @returns {string}
+ */
+export function getEffectiveBackupText(settings) {
+    const durable = readDurableMainSyspromptBackup();
+    const picked = pickPreferredBackupText(
+        settings?.stashedMainSysprompt,
+        durable,
+        settings?.mainSyspromptBackupTs,
+    );
+    if (settings && picked !== String(settings.stashedMainSysprompt ?? '')) {
+        settings.stashedMainSysprompt = picked;
+        settings.syspromptStashArmed = !!picked.trim();
+    }
+    if (picked.trim() && durable?.text !== picked) {
+        writeDurableMainSyspromptBackup(picked);
+    }
+    return picked;
+}
+
+/**
+ * @param {Record<string, any>} settings
+ * @returns {boolean} true if settings were healed from localStorage
+ */
+export function hydrateMainSyspromptBackup(settings) {
+    if (!settings || typeof settings !== 'object') return false;
+    const before = String(settings.stashedMainSysprompt ?? '');
+    const after = getEffectiveBackupText(settings);
+    if (after.trim() && !before.trim()) {
+        settings.syspromptStashArmed = true;
+        return true;
+    }
+    if (after && after !== before) {
+        settings.syspromptStashArmed = !!after.trim();
+        return true;
+    }
+    return false;
+}
+
+/**
+ * @param {string} existingText
+ * @param {string} candidateText
+ * @param {{ manual?: boolean, builtFrameworkText?: string }} [opts]
+ * @returns {boolean}
+ */
+export function shouldReplaceBackup(existingText, candidateText, opts = {}) {
+    const existing = String(existingText ?? '');
+    const candidate = String(candidateText ?? '');
+    if (!candidate.trim()) return false;
+    if (candidate === existing) return false;
+
+    const candidateIsFramework = looksLikeFrameworkSysprompt(candidate, opts.builtFrameworkText);
+    // Never store the framework narrator prompt as the user's original Main —
+    // including an explicit Save click while the tracker is already managing Main.
+    if (candidateIsFramework) return false;
+
+    if (opts.manual) return true;
+    if (!existing.trim()) return true;
+    if (looksLikeFrameworkSysprompt(existing, opts.builtFrameworkText)) return true;
+    return true;
+}
+
+/**
+ * Snapshot live Main into the durable backup *before* the framework overwrites it.
+ * @param {Record<string, any>} settings
+ * @param {{ force?: boolean, manual?: boolean, builtFrameworkText?: string }} [opts]
+ * @returns {{ ok: boolean, shouldDefer: boolean, changed: boolean, reason: string }}
+ */
+export function captureMainSyspromptBackup(settings, opts = {}) {
+    const manual = !!opts.manual;
+    if (!settings || !isMainSyspromptBackupEnabled(settings)) {
+        return { ok: true, shouldDefer: false, changed: false, reason: 'disabled' };
+    }
+    if (!manual && (settings.customSysprompt || !settings.enabled)) {
+        return { ok: true, shouldDefer: false, changed: false, reason: 'skipped' };
+    }
+
+    hydrateMainSyspromptBackup(settings);
+    const existing = String(settings.stashedMainSysprompt ?? '');
+    const sourceReady = isMainSyspromptSourceReady();
+    const live = getLiveMainSyspromptText();
+
+    if (manual && !live.trim()) {
+        return { ok: false, shouldDefer: false, changed: false, reason: 'empty' };
+    }
+
+    if (!sourceReady && !existing.trim() && !manual) {
+        return { ok: false, shouldDefer: true, changed: false, reason: 'source-not-ready' };
+    }
+
+    if (!live.trim()) {
+        // Ready empty Main: nothing to capture. Keep any existing backup.
+        return { ok: true, shouldDefer: false, changed: false, reason: existing.trim() ? 'kept' : 'nothing-to-capture' };
+    }
+
+    if (!shouldReplaceBackup(existing, live, opts)) {
+        const haveBackup = !!existing.trim();
+        const liveIsFramework = looksLikeFrameworkSysprompt(live, opts.builtFrameworkText);
+        if (haveBackup) settings.syspromptStashArmed = true;
+        if (liveIsFramework) {
+            return { ok: true, shouldDefer: false, changed: false, reason: 'already-framework' };
+        }
+        if (haveBackup) {
+            return { ok: true, shouldDefer: false, changed: false, reason: 'kept' };
+        }
+        return { ok: false, shouldDefer: !sourceReady, changed: false, reason: 'rejected' };
+    }
+
+    settings.stashedMainSysprompt = live;
+    settings.syspromptStashArmed = true;
+    settings.mainSyspromptBackupTs = writeDurableMainSyspromptBackup(live);
+    return { ok: true, shouldDefer: false, changed: true, reason: 'captured' };
+}
+
+/**
+ * Restore the durable backup into live Main. The backup itself is never disarmed.
+ * @param {Record<string, any>} settings
+ * @param {{ manual?: boolean }} [opts]
+ * @returns {boolean}
+ */
+export function restoreMainSyspromptStash(settings, opts = {}) {
+    const manual = !!opts.manual;
+    if (!settings || !isMainSyspromptBackupEnabled(settings)) return false;
+    if (!manual && settings.customSysprompt) return false;
+    hydrateMainSyspromptBackup(settings);
+    const text = String(settings.stashedMainSysprompt ?? '');
+    if (!text.trim()) return false;
+    settings.syspromptStashArmed = true;
+    return setLiveMainSyspromptText(text);
+}
+
+/**
+ * If the tracker is off but Main still holds the framework prompt (restore missed
+ * the textarea on disable, or the extension was disabled mid-session), put the
+ * user's backup back.
+ * @param {Record<string, any>} settings
+ * @returns {boolean}
+ */
+export function maybeRestoreMainIfTrackerDisabled(settings) {
+    if (!settings || settings.enabled || settings.customSysprompt) return false;
+    if (!isMainSyspromptBackupEnabled(settings)) return false;
+    if (!isMainSyspromptSourceReady()) return false;
+    hydrateMainSyspromptBackup(settings);
+    const backup = String(settings.stashedMainSysprompt ?? '');
+    if (!backup.trim()) return false;
+    const live = getLiveMainSyspromptText();
+    if (live.trim() && !looksLikeFrameworkSysprompt(live) && live !== backup) return false;
+    if (live === backup) return false;
+    return restoreMainSyspromptStash(settings);
+}

--- a/state-manager.js
+++ b/state-manager.js
@@ -23,6 +23,7 @@ export * from './src/state/factory-and-diff.js';
 export * from './src/state/settings.js';
 export * from './src/state/chat-persistence.js';
 export * from './src/state/critical-settings-backup.js';
+export * from './src/state/main-sysprompt-backup.js';
 export * from './src/state/chat-setup.js';
 export * from './src/state/profiles.js';
 export * from './src/state/router-utils.js';

--- a/tests/main-sysprompt-backup.test.js
+++ b/tests/main-sysprompt-backup.test.js
@@ -1,0 +1,216 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { clearExtensionLocalStorageUiState } from '../src/state/defaults.js';
+import {
+    MAIN_SYSPROMPT_BACKUP_KEY,
+    captureMainSyspromptBackup,
+    getEffectiveBackupText,
+    getLiveMainSyspromptText,
+    hydrateMainSyspromptBackup,
+    looksLikeFrameworkSysprompt,
+    maybeRestoreMainIfTrackerDisabled,
+    pickPreferredBackupText,
+    readDurableMainSyspromptBackup,
+    restoreMainSyspromptStash,
+    setLiveMainSyspromptText,
+    shouldReplaceBackup,
+    writeDurableMainSyspromptBackup,
+} from '../src/state/main-sysprompt-backup.js';
+
+const USER_PROMPT = 'Write {{char}} next reply in a fictional roleplay.';
+const FRAMEWORK_PROMPT = `<role>
+DM/World Simulator for a D&D-style TTRPG. Narrate the world.
+</role>
+<rng_system>
+- [RNG_QUEUE v7.0] is the sole RNG mechanic
+</rng_system>`;
+
+function installHost({ textareaValue = null, mainContent = '', saveCalls } = {}) {
+    const ta = textareaValue == null
+        ? null
+        : {
+            value: textareaValue,
+            dispatchEvent() {},
+        };
+    globalThis.document = {
+        getElementById(id) {
+            return id === 'main_prompt_quick_edit_textarea' ? ta : null;
+        },
+    };
+    const oai = {
+        prompts: [{ identifier: 'main', content: mainContent }],
+        main_prompt: mainContent,
+    };
+    const previous = globalThis.SillyTavern.getContext;
+    globalThis.SillyTavern.getContext = () => ({
+        ...previous(),
+        chatCompletionSettings: oai,
+        saveSettingsDebounced: () => {
+            if (saveCalls) saveCalls.push(oai.prompts[0].content);
+        },
+    });
+    return { ta, oai };
+}
+
+const originalGetContext = globalThis.SillyTavern.getContext;
+
+describe('main sysprompt backup', () => {
+    beforeEach(() => {
+        localStorage.clear();
+        globalThis.SillyTavern.getContext = originalGetContext;
+        installHost({ textareaValue: '', mainContent: '' });
+    });
+
+    it('prefers Prompt Manager content over an unhydrated empty textarea', () => {
+        installHost({ textareaValue: '', mainContent: USER_PROMPT });
+        expect(getLiveMainSyspromptText()).toBe(USER_PROMPT);
+    });
+
+    it('never writes an empty string over a durable non-empty backup', () => {
+        writeDurableMainSyspromptBackup(USER_PROMPT);
+        writeDurableMainSyspromptBackup('');
+        expect(readDurableMainSyspromptBackup()?.text).toBe(USER_PROMPT);
+    });
+
+    it('heals empty settings from localStorage after a cancelled disk save', () => {
+        writeDurableMainSyspromptBackup(USER_PROMPT);
+        const settings = { stashedMainSysprompt: '', syspromptStashArmed: false };
+        expect(hydrateMainSyspromptBackup(settings)).toBe(true);
+        expect(settings.stashedMainSysprompt).toBe(USER_PROMPT);
+        expect(settings.syspromptStashArmed).toBe(true);
+        expect(getEffectiveBackupText(settings)).toBe(USER_PROMPT);
+    });
+
+    it('does not replace a user backup with the framework narrator prompt', () => {
+        expect(shouldReplaceBackup(USER_PROMPT, FRAMEWORK_PROMPT, {
+            builtFrameworkText: FRAMEWORK_PROMPT,
+        })).toBe(false);
+        expect(shouldReplaceBackup(USER_PROMPT, FRAMEWORK_PROMPT, {
+            manual: true,
+            builtFrameworkText: FRAMEWORK_PROMPT,
+        })).toBe(false);
+        expect(looksLikeFrameworkSysprompt(FRAMEWORK_PROMPT, FRAMEWORK_PROMPT)).toBe(true);
+    });
+
+    it('captures live Main before overwrite and keeps it when re-enabled on the framework prompt', () => {
+        installHost({ textareaValue: '', mainContent: USER_PROMPT });
+        const settings = {
+            enabled: true,
+            customSysprompt: false,
+            mainSyspromptBackupEnabled: true,
+            stashedMainSysprompt: '',
+            syspromptStashArmed: false,
+        };
+
+        const first = captureMainSyspromptBackup(settings, { builtFrameworkText: FRAMEWORK_PROMPT });
+        expect(first).toMatchObject({ ok: true, changed: true, reason: 'captured' });
+        expect(settings.stashedMainSysprompt).toBe(USER_PROMPT);
+        expect(readDurableMainSyspromptBackup()?.text).toBe(USER_PROMPT);
+
+        installHost({ textareaValue: FRAMEWORK_PROMPT, mainContent: FRAMEWORK_PROMPT });
+        const second = captureMainSyspromptBackup(settings, { builtFrameworkText: FRAMEWORK_PROMPT });
+        expect(second.changed).toBe(false);
+        expect(settings.stashedMainSysprompt).toBe(USER_PROMPT);
+        expect(readDurableMainSyspromptBackup()?.text).toBe(USER_PROMPT);
+    });
+
+    it('defers capture when Prompt Manager has not loaded yet and no backup exists', () => {
+        globalThis.document = { getElementById: () => null };
+        globalThis.SillyTavern.getContext = () => ({
+            extensionSettings: {},
+            chatId: 'vitest-chat',
+            saveSettingsDebounced() {},
+        });
+        const settings = {
+            enabled: true,
+            customSysprompt: false,
+            mainSyspromptBackupEnabled: true,
+            stashedMainSysprompt: '',
+        };
+        const result = captureMainSyspromptBackup(settings);
+        expect(result.shouldDefer).toBe(true);
+        expect(result.ok).toBe(false);
+    });
+
+    it('restores through Prompt Manager when the Quick Prompt textarea is missing', () => {
+        const saveCalls = [];
+        installHost({ textareaValue: null, mainContent: FRAMEWORK_PROMPT, saveCalls });
+        const settings = {
+            enabled: false,
+            customSysprompt: false,
+            mainSyspromptBackupEnabled: true,
+            stashedMainSysprompt: USER_PROMPT,
+            syspromptStashArmed: true,
+        };
+        writeDurableMainSyspromptBackup(USER_PROMPT);
+
+        expect(restoreMainSyspromptStash(settings)).toBe(true);
+        const ctx = globalThis.SillyTavern.getContext();
+        expect(ctx.chatCompletionSettings.prompts[0].content).toBe(USER_PROMPT);
+        expect(settings.syspromptStashArmed).toBe(true);
+        expect(readDurableMainSyspromptBackup()?.text).toBe(USER_PROMPT);
+    });
+
+    it('puts the backup back when the tracker is off but Main still has the framework prompt', () => {
+        installHost({ textareaValue: FRAMEWORK_PROMPT, mainContent: FRAMEWORK_PROMPT });
+        const settings = {
+            enabled: false,
+            customSysprompt: false,
+            mainSyspromptBackupEnabled: true,
+            stashedMainSysprompt: USER_PROMPT,
+        };
+        writeDurableMainSyspromptBackup(USER_PROMPT);
+        expect(maybeRestoreMainIfTrackerDisabled(settings)).toBe(true);
+        expect(getLiveMainSyspromptText()).toBe(USER_PROMPT);
+    });
+
+    it('refuses to save an empty Main over an existing backup', () => {
+        installHost({ textareaValue: '', mainContent: '' });
+        const settings = {
+            enabled: true,
+            customSysprompt: false,
+            mainSyspromptBackupEnabled: true,
+            stashedMainSysprompt: USER_PROMPT,
+            syspromptStashArmed: true,
+        };
+        writeDurableMainSyspromptBackup(USER_PROMPT);
+        const result = captureMainSyspromptBackup(settings, { manual: true });
+        expect(result).toMatchObject({ ok: false, reason: 'empty' });
+        expect(getEffectiveBackupText(settings)).toBe(USER_PROMPT);
+    });
+
+    it('writes Main even when only Prompt Manager is available', () => {
+        const saveCalls = [];
+        installHost({ textareaValue: null, mainContent: USER_PROMPT, saveCalls });
+        expect(setLiveMainSyspromptText(FRAMEWORK_PROMPT)).toBe(true);
+        expect(globalThis.SillyTavern.getContext().chatCompletionSettings.prompts[0].content).toBe(FRAMEWORK_PROMPT);
+        expect(saveCalls).toEqual([FRAMEWORK_PROMPT]);
+    });
+
+    it('prefers a non-framework localStorage copy over a framework-shaped settings copy', () => {
+        const picked = pickPreferredBackupText(FRAMEWORK_PROMPT, { ts: 1, text: USER_PROMPT });
+        expect(picked).toBe(USER_PROMPT);
+    });
+
+    it('prefers a newer shorter user backup over an older longer copy', () => {
+        const picked = pickPreferredBackupText('old longer original prompt text', { ts: 50, text: 'newer' }, 10);
+        expect(picked).toBe('newer');
+    });
+
+    it('does not delete the Main backup during factory-reset UI localStorage wipe', () => {
+        writeDurableMainSyspromptBackup(USER_PROMPT);
+        localStorage.setItem('rpg_tracker_collapsed', 'true');
+        clearExtensionLocalStorageUiState();
+        expect(localStorage.getItem('rpg_tracker_collapsed')).toBeNull();
+        expect(readDurableMainSyspromptBackup()?.text).toBe(USER_PROMPT);
+        expect(localStorage.getItem(MAIN_SYSPROMPT_BACKUP_KEY)).toBeTruthy();
+    });
+
+    it('captures the backup in autoApply before writing the framework prompt', () => {
+        const src = readFileSync(new URL('../index.js', import.meta.url), 'utf8');
+        const captureAt = src.indexOf('captureMainSyspromptBackup(s, { builtFrameworkText: built })');
+        const writeAt = src.indexOf('setLiveMainSyspromptText(built)');
+        expect(captureAt).toBeGreaterThan(0);
+        expect(writeAt).toBeGreaterThan(captureAt);
+    });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

The original Quick Prompt Main backup could go empty or vanish after a framework update / reload, so clicking ⏻ left the D&D narrator prompt in Main instead of restoring the user’s previous system prompt.

That happened because the snapshot was taken from the Quick Edit textarea (often still empty while Prompt Manager hydrated), stored only in the cancellable `settings.json` save, force-overwritten when re-enabling the tracker, and disarmed on disable so the UI treated it as gone.

## What changed

- Capture Main **before** overwrite, reading Prompt Manager / `oai_settings` when the textarea is empty or missing.
- Dual-write to a sync browser-local backup that is **never replaced with empty or with the framework prompt**, and is kept when the tracker or extension is turned off (including factory-reset UI wipe).
- Restore on ⏻ even if Quick Prompts is closed. If the tracker is already off but Main still holds the D&D prompt, boot puts the backup back.
- Version **8.1.3** for SillyTavern auto-update.

## Tests

`npx vitest run` — 690 passed, including new `tests/main-sysprompt-backup.test.js`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c6d991ba-940e-4ed5-91a0-dab96b0a05ee?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c6d991ba-940e-4ed5-91a0-dab96b0a05ee&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

