### PR TITLE
Stop map asset trees from recursing on containment loops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the **Multihog D&D Framework** will be documented in this file.
 
+## [2026.8.52] - 2026-08-25
+
+### Fixed
+- **Map containment loops in narrator prose**: Narrator, player, and Map Updater snapshots no longer recurse forever when an asset id collides with its room or containment otherwise loops. Map Details already stopped; the hotter LLM-facing trees now use the same cutoff.
+
 ## [2026.8.51] - 2026-08-25
 
 ### Fixed

--- a/dungeon-reality.js
+++ b/dungeon-reality.js
@@ -952,6 +952,30 @@ export function parseEditableDungeonMapJson(text, siteRoot = '') {
     return { ok: true, errors: [], document };
 }
 
+function mapAssetId(asset) {
+    return String(asset?.id || '').trim();
+}
+
+function listDirectContainedAssets(assets, parentId, ancestors = new Set()) {
+    const id = String(parentId || '').trim();
+    if (!id) return [];
+    return (assets || []).filter((candidate) => {
+        const childId = mapAssetId(candidate);
+        if (!childId || ancestors.has(childId)) return false;
+        return String(candidate.location || '').trim() === id;
+    });
+}
+
+function isContainedByOtherAsset(assets, asset) {
+    const loc = String(asset?.location || '').trim();
+    const id = mapAssetId(asset);
+    if (!loc) return false;
+    return (assets || []).some((parent) => {
+        const parentId = mapAssetId(parent);
+        return parentId && parentId === loc && parentId !== id;
+    });
+}
+
 function formatMapAsset(asset, areasById, depth = 0) {
     const indent = '  '.repeat(depth);
     const tags = [asset.kind, asset.state, asset.knowledge].filter(Boolean).join(' / ');
@@ -975,11 +999,15 @@ function formatMapAsset(asset, areasById, depth = 0) {
     return lines;
 }
 
-function formatMapAssetTree(document, asset, areasById, { visible = () => true, depth = 0 } = {}) {
+function formatMapAssetTree(document, asset, areasById, { visible = () => true, depth = 0, ancestors = new Set() } = {}) {
     if (!visible(asset)) return [];
+    const id = mapAssetId(asset);
+    if (id && ancestors.has(id)) return [];
+    const nested = new Set(ancestors);
+    if (id) nested.add(id);
     const lines = formatMapAsset(asset, areasById, depth);
-    for (const child of document.assets.filter(candidate => candidate.location === asset.id)) {
-        lines.push(...formatMapAssetTree(document, child, areasById, { visible, depth: depth + 1 }));
+    for (const child of listDirectContainedAssets(document.assets, id, nested)) {
+        lines.push(...formatMapAssetTree(document, child, areasById, { visible, depth: depth + 1, ancestors: nested }));
     }
     return lines;
 }
@@ -1050,7 +1078,7 @@ export function formatDungeonMapForNarrator(documentOrContent, siteFallback = ''
             for (const asset of assets) lines.push(...formatMapAssetTree(document, asset, areasById));
         }
     }
-    const unplacedRoots = unplacedAssets.filter(asset => !document.assets.some(parent => parent.id === asset.location));
+    const unplacedRoots = unplacedAssets.filter(asset => !isContainedByOtherAsset(document.assets, asset));
     if (unplacedRoots.length) {
         lines.push('', 'Removed / unplaced assets:');
         for (const asset of unplacedRoots) {
@@ -1846,11 +1874,18 @@ function resolveMapEffectiveArea(document, ref) {
 
 export function listContainedMapAssets(document, containerRef, { recursive = false } = {}) {
     const map = normalizeDungeonMapDocument(document, document?.site);
-    const container = resolveMapAsset(map, containerRef).asset;
-    if (!container) return [];
-    const direct = map.assets.filter(asset => asset.location === container.id);
-    if (!recursive) return direct;
-    return direct.flatMap(asset => [asset, ...listContainedMapAssets(map, asset.id, { recursive: true })]);
+    const walk = (ref, ancestors) => {
+        const container = resolveMapAsset(map, ref).asset;
+        if (!container) return [];
+        const containerId = mapAssetId(container);
+        if (!containerId || ancestors.has(containerId)) return [];
+        const nested = new Set(ancestors);
+        nested.add(containerId);
+        const direct = listDirectContainedAssets(map.assets, containerId, nested);
+        if (!recursive) return direct;
+        return direct.flatMap(asset => [asset, ...walk(asset.id, nested)]);
+    };
+    return walk(containerRef, new Set());
 }
 
 function collectAssetDeletionIds(document, rootId) {
@@ -2413,19 +2448,38 @@ export function formatDungeonMapForUpdater(document, currentLocation = '', optio
     });
     const assetDepth = (asset) => {
         let depth = 0;
-        let parent = map.assets.find(candidate => candidate.id === asset.location);
+        const seen = new Set([mapAssetId(asset)].filter(Boolean));
+        let parent = map.assets.find(candidate => {
+            const parentId = mapAssetId(candidate);
+            return parentId && parentId === String(asset.location || '').trim() && parentId !== mapAssetId(asset);
+        });
         while (parent && depth < 4) {
+            const parentId = mapAssetId(parent);
+            if (parentId && seen.has(parentId)) break;
+            if (parentId) seen.add(parentId);
             depth++;
-            parent = map.assets.find(candidate => candidate.id === parent.location);
+            parent = map.assets.find(candidate => {
+                const candidateId = mapAssetId(candidate);
+                return candidateId && candidateId === String(parent.location || '').trim() && candidateId !== parentId;
+            });
         }
         return depth;
     };
     const orderedAssets = [];
+    const seenAssets = new Set();
     const appendAsset = (asset) => {
+        if (seenAssets.has(asset)) return;
+        seenAssets.add(asset);
         orderedAssets.push(asset);
-        for (const child of map.assets.filter(candidate => candidate.location === asset.id)) appendAsset(child);
+        const id = mapAssetId(asset);
+        if (!id) return;
+        for (const child of map.assets) {
+            if (seenAssets.has(child)) continue;
+            if (String(child.location || '').trim() !== id) continue;
+            appendAsset(child);
+        }
     };
-    for (const asset of map.assets.filter(candidate => !map.assets.some(parent => parent.id === candidate.location))) appendAsset(asset);
+    for (const asset of map.assets.filter(candidate => !isContainedByOtherAsset(map.assets, candidate))) appendAsset(asset);
     const assetLines = orderedAssets.map(asset => {
         const bits = [asset.id, asset.kind, asset.name, `loc=${asset.location}`, asset.state, asset.knowledge];
         if (asset.kind === 'BUILDING') bits.push(`notEntered=${asset.notEntered !== false}`);

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
 
     "display_name": "Multihog D&D Framework",
 
-    "version": "2026.8.51",
+    "version": "2026.8.52",
 
     "author": "Disgusting Fatbody",
 

--- a/tests/dungeon-reality.test.js
+++ b/tests/dungeon-reality.test.js
@@ -777,6 +777,60 @@ Area: Ossuary Behind Rotten Tapestry
         expect(readable).not.toContain('DEADLY');
     });
 
+    it('nests contained assets under their container in narrator prose', () => {
+        const map = {
+            version: 3,
+            site: 'Ashford',
+            kind: 'SETTLEMENT',
+            areas: [{ id: 'north', name: 'North Residential Streets', knowledge: 'VISITED', geometry: [], connections: [] }],
+            assets: [
+                { id: 'house', kind: 'BUILDING', name: 'Residential House', location: 'north', state: 'ACTIVE', knowledge: 'KNOWN', detail: '', origin: 'INITIAL_MAP' },
+                { id: 'caretaker', kind: 'CREATURE', name: 'Caretaker', location: 'house', state: 'ACTIVE', knowledge: 'KNOWN', detail: '', origin: 'INITIAL_MAP' },
+                { id: 'brass-key', kind: 'LOOT', name: 'Brass Key', location: 'caretaker', state: 'AVAILABLE', knowledge: 'SUSPECTED', detail: '', origin: 'INITIAL_MAP' },
+            ],
+        };
+        const readable = formatDungeonMapForNarrator(map);
+        expect(readable).toMatch(/- Residential House \[BUILDING[^\n]*\n\s+- Caretaker \[CREATURE[^\n]*\n\s+- Brass Key \[LOOT/);
+        const snapshot = formatDungeonMapForUpdater(map);
+        expect(snapshot.indexOf('caretaker | CREATURE')).toBeGreaterThan(snapshot.indexOf('house | BUILDING'));
+        expect(snapshot.indexOf('brass-key | LOOT')).toBeGreaterThan(snapshot.indexOf('caretaker | CREATURE'));
+    });
+
+    it('does not recurse forever when narrator map asset containment loops', () => {
+        const map = {
+            version: 3, site: 'Loop Site', kind: 'DUNGEON',
+            areas: [{ id: 'hall', name: 'Hall', knowledge: 'VISITED', geometry: [], connections: [] }],
+            assets: [
+                { kind: 'OBJECT', name: 'Nameless A', location: 'hall', state: 'ACTIVE', knowledge: 'KNOWN', detail: '', origin: 'INITIAL_MAP' },
+                { kind: 'OBJECT', name: 'Nameless B', location: 'hall', state: 'ACTIVE', knowledge: 'KNOWN', detail: '', origin: 'INITIAL_MAP' },
+                { id: 'hall', kind: 'GROUP', name: 'Hall Pack', location: 'hall', state: 'ACTIVE', knowledge: 'KNOWN', detail: '', origin: 'INITIAL_MAP' },
+                { id: 'alpha', kind: 'CREATURE', name: 'Alpha', location: 'hall', state: 'ACTIVE', knowledge: 'KNOWN', detail: '', origin: 'INITIAL_MAP' },
+                { id: 'beta', kind: 'CREATURE', name: 'Beta', location: 'alpha', state: 'ACTIVE', knowledge: 'KNOWN', detail: '', origin: 'INITIAL_MAP' },
+            ],
+        };
+        const readable = formatDungeonMapForNarrator(map);
+        expect(readable).toContain('Nameless A');
+        expect(readable).toContain('Nameless B');
+        expect(readable).toContain('Hall Pack');
+        expect(readable).toContain('Alpha');
+        expect(readable).toContain('Beta');
+        expect((readable.match(/Hall Pack/g) || []).length).toBe(1);
+        expect(readable.indexOf('Beta')).toBeGreaterThan(readable.indexOf('Alpha'));
+
+        const player = formatDungeonMapForPlayer(map, 'Loop Site, Hall');
+        expect(player).toContain('Hall Pack');
+        expect(player).toContain('Nameless A');
+        expect((player.match(/Hall Pack/g) || []).length).toBe(1);
+
+        const snapshot = formatDungeonMapForUpdater(map, 'Loop Site, Hall');
+        expect(snapshot).toContain('Hall Pack');
+        expect(snapshot).toContain('Nameless A');
+        expect(snapshot).toContain('alpha | CREATURE | Alpha');
+        expect(snapshot).toContain('beta | CREATURE | Beta');
+
+        expect(listContainedMapAssets(map, 'hall', { recursive: true }).map(asset => asset.name)).toEqual(['Nameless A', 'Nameless B', 'Alpha', 'Beta']);
+    });
+
     it('uses explicit child chronicles once when establishing current state from a legacy map', () => {
         const root = {
             comment: 'Abbey Undercroft',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The Map Details inspector already cut off asset-tree re-entry when containment loops (asset id colliding with its room, duplicate/empty ids, A→B→A). The same unguarded walk was still used to build narrator prose, player-facing map text, and the Map Updater occupancy snapshot.

**What was happening**

`formatMapAssetTree` in `dungeon-reality.js` recursed with `document.assets.filter(candidate => candidate.location === asset.id)` and no ancestor set. The Hall Pack fixture (`id: 'hall'`, `location: 'hall'` in a room also named `hall`) is bucketed into that area, then treated as its own child forever. That path is what the narrator LLM sees.

`formatDungeonMapForUpdater`'s `appendAsset` and recursive `listContainedMapAssets` had the same pattern.

**Fix**

- Track ancestor ids in `formatMapAssetTree` and skip already-seen / empty child ids, matching Map Details.
- Stop updater forest walks on seen objects, and do not treat an asset as its own parent when choosing roots.
- Guard recursive `listContainedMapAssets` the same way.

Tests cover legitimate house→caretaker→key nesting plus the Hall Pack loop across narrator, player, updater, and contained-asset listing. Full vitest suite: 861 passed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-154b425b-7e29-45e2-b3fa-7828d506da49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-154b425b-7e29-45e2-b3fa-7828d506da49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

