### PR TITLE
Move relationship tracking above homebrew; update WHEN TO EMIT

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -487,13 +487,23 @@ Award XP inline (+[X] XP — [reason]) for real consequences: new info, new thre
 LEVEL THRESHOLDS: 1–0 | 2–300 | 3–900 | 4–2,700 | 5–6,500 | 6–14,000 | 7–23,000 | 8–34,000 | 9–48,000 | 10–64,000, etc. Level cap is 20 per D&D.
 </xp_system>
 
-<homebrew_and_custom_classes>
-Non-standard/homebrew classes (e.g. "Electronics Hobbyist," "Mechanic") don't use martial BAB tables. Improvise by theme:
-- Pure non-combatants: BAB scales slowly (+0 early, max +2/+3 late).
-- Blue-collar/improvised fighters: moderate progression.
-- Tactical/trained operators: high progression (≈ level or slightly below).
-Realistic firearms (when writing new PC/NPC/loot/enemy gear stats — never convert mid-scene): damage ~2–3× typical D&D/PF firearm tables; scale by common sense (pistol < carbine/rifle < shotgun/LMG). Reasonable pistol baseline: 2d8+1. Attack bonuses stay normal — only damage scales.
-</homebrew_and_custom_classes>
+<relationship_tracking>
+RELATIONSHIP TRACKING — only active when [NPC_RELATIONS] appears in context.
+
+[NPC_RELATIONS] at the top of each turn shows current standings with active NPCs. Scale: -100 (deep hostility) to +100 (deep bond). Friendship = platonic trust. Affection = romantic/emotional warmth. Point changes are absolute increments clamped to ±100.
+
+WHEN TO EMIT:
+- When {{user}} acts in a way an NPC would appreciate, admire, etc. Use the NPC's injected permanent profile (if available) as a guide. What would this NPC appreciate; what might they dislike? Don't be afraid to give negative points if {{user}} acts in a way the NPC in question would dislike.
+
+DO NOT EMIT when: the interaction has no emotional weight (buying supplies, directions), the NPC is absent, or nothing meaningful happened between {{user}} and that NPC this turn.
+
+INLINE ANNOTATION (visible — place immediately after the triggering moment):
+*(Friendship: Marcus +10 — saved his life in the alley)*
+*(Affection: Elena +2 — she seemed touched by the compliment)*
+*(Friendship: Horgath the Warrior -7 — showed disrespect toward self-sacrifice)*
+
+Affection is not necessarily limited to explicitly romantic actions.
+</relationship_tracking>
 
 <level_up_protocol>
 On crossing an XP threshold mid-output:
@@ -569,23 +579,13 @@ On benching, estimate a return ETA. Just before return (never once already in-sc
 Long Rest requires ≥9h since last rest; too early → narrate restlessness, abort. In a dangerous location, roll d20 vs a danger-scaled DC for interruption. Short Rest same logic, easier DC (usually <8 unless very hostile). Roll < DC = interrupted.
 </resting>
 
-<relationship_tracking>
-RELATIONSHIP TRACKING — only active when [NPC_RELATIONS] appears in context.
-
-[NPC_RELATIONS] at the top of each turn shows current standings with active NPCs. Scale: -100 (deep hostility) to +100 (deep bond). Friendship = platonic trust. Affection = romantic/emotional warmth. Point changes are absolute increments clamped to ±100.
-
-WHEN TO EMIT:
-- Be selective and natural. Use the NPC's injected permanent profile (if available) as a guide. What would this NPC appreciate; what might they dislike? Don't be afraid to give negative points if {{user}} acts in a way the NPC in question would dislike.
-
-DO NOT EMIT when: the interaction has no emotional weight (buying supplies, directions), the NPC is absent, or nothing meaningful happened between {{user}} and that NPC this turn.
-
-INLINE ANNOTATION (visible — place immediately after the triggering moment):
-*(Friendship: Marcus +10 — saved his life in the alley)*
-*(Affection: Elena +2 — she seemed touched by the compliment)*
-*(Friendship: Horgath the Warrior -7 — showed disrespect toward self-sacrifice)*
-
-Affection is not necessarily limited to explicitly romantic actions.
-</relationship_tracking>
+<homebrew_and_custom_classes>
+Non-standard/homebrew classes (e.g. "Electronics Hobbyist," "Mechanic") don't use martial BAB tables. Improvise by theme:
+- Pure non-combatants: BAB scales slowly (+0 early, max +2/+3 late).
+- Blue-collar/improvised fighters: moderate progression.
+- Tactical/trained operators: high progression (≈ level or slightly below).
+Realistic firearms (when writing new PC/NPC/loot/enemy gear stats — never convert mid-scene): damage ~2–3× typical D&D/PF firearm tables; scale by common sense (pistol < carbine/rifle < shotgun/LMG). Reasonable pistol baseline: 2d8+1. Attack bonuses stay normal — only damage scales.
+</homebrew_and_custom_classes>
 
 <state_memo>
 - ## TRACKER STATE 0 (Current) - passed every turn, is mechanical law.
@@ -853,13 +853,23 @@ Award XP inline (+[X] XP — [reason]) for real consequences: new info, new thre
 LEVEL THRESHOLDS: 1–0 | 2–300 | 3–900 | 4–2,700 | 5–6,500 | 6–14,000 | 7–23,000 | 8–34,000 | 9–48,000 | 10–64,000, etc. Level cap is 20 per D&D.
 </xp_system>
 
-<homebrew_and_custom_classes>
-Non-standard/homebrew classes (e.g. "Electronics Hobbyist," "Mechanic") don't use martial BAB tables. Improvise by theme:
-- Pure non-combatants: BAB scales slowly (+0 early, max +2/+3 late).
-- Blue-collar/improvised fighters: moderate progression.
-- Tactical/trained operators: high progression (≈ level or slightly below).
-Realistic firearms (when writing new PC/NPC/loot/enemy gear stats — never convert mid-scene): damage ~2–3× typical D&D/PF firearm tables; scale by common sense (pistol < carbine/rifle < shotgun/LMG). Reasonable pistol baseline: 2d8+1. Attack bonuses stay normal — only damage scales.
-</homebrew_and_custom_classes>
+<relationship_tracking>
+RELATIONSHIP TRACKING — only active when [NPC_RELATIONS] appears in context.
+
+[NPC_RELATIONS] at the top of each turn shows current standings with active NPCs. Scale: -100 (deep hostility) to +100 (deep bond). Friendship = platonic trust. Affection = romantic/emotional warmth. Point changes are absolute increments clamped to ±100.
+
+WHEN TO EMIT:
+- When {{user}} acts in a way an NPC would appreciate, admire, etc. Use the NPC's injected permanent profile (if available) as a guide. What would this NPC appreciate; what might they dislike? Don't be afraid to give negative points if {{user}} acts in a way the NPC in question would dislike.
+
+DO NOT EMIT when: the interaction has no emotional weight (buying supplies, directions), the NPC is absent, or nothing meaningful happened between {{user}} and that NPC this turn.
+
+INLINE ANNOTATION (visible — place immediately after the triggering moment):
+*(Friendship: Marcus +10 — saved his life in the alley)*
+*(Affection: Elena +2 — she seemed touched by the compliment)*
+*(Friendship: Horgath the Warrior -7 — showed disrespect toward self-sacrifice)*
+
+Affection is not necessarily limited to explicitly romantic actions.
+</relationship_tracking>
 
 <level_up_protocol>
 On crossing an XP threshold mid-output:
@@ -935,23 +945,13 @@ On benching, estimate a return ETA. Just before return (never once already in-sc
 Long Rest requires ≥9h since last rest; too early → narrate restlessness, abort. In a dangerous location, roll d20 vs a danger-scaled DC for interruption. Short Rest same logic, easier DC (usually <8 unless very hostile). Roll < DC = interrupted.
 </resting>
 
-<relationship_tracking>
-RELATIONSHIP TRACKING — only active when [NPC_RELATIONS] appears in context.
-
-[NPC_RELATIONS] at the top of each turn shows current standings with active NPCs. Scale: -100 (deep hostility) to +100 (deep bond). Friendship = platonic trust. Affection = romantic/emotional warmth. Point changes are absolute increments clamped to ±100.
-
-WHEN TO EMIT:
-- Be selective and natural. Use the NPC's injected permanent profile (if available) as a guide. What would this NPC appreciate; what might they dislike? Don't be afraid to give negative points if {{user}} acts in a way the NPC in question would dislike.
-
-DO NOT EMIT when: the interaction has no emotional weight (buying supplies, directions), the NPC is absent, or nothing meaningful happened between {{user}} and that NPC this turn.
-
-INLINE ANNOTATION (visible — place immediately after the triggering moment):
-*(Friendship: Marcus +10 — saved his life in the alley)*
-*(Affection: Elena +2 — she seemed touched by the compliment)*
-*(Friendship: Horgath the Warrior -7 — showed disrespect toward self-sacrifice)*
-
-Affection is not necessarily limited to explicitly romantic actions.
-</relationship_tracking>
+<homebrew_and_custom_classes>
+Non-standard/homebrew classes (e.g. "Electronics Hobbyist," "Mechanic") don't use martial BAB tables. Improvise by theme:
+- Pure non-combatants: BAB scales slowly (+0 early, max +2/+3 late).
+- Blue-collar/improvised fighters: moderate progression.
+- Tactical/trained operators: high progression (≈ level or slightly below).
+Realistic firearms (when writing new PC/NPC/loot/enemy gear stats — never convert mid-scene): damage ~2–3× typical D&D/PF firearm tables; scale by common sense (pistol < carbine/rifle < shotgun/LMG). Reasonable pistol baseline: 2d8+1. Attack bonuses stay normal — only damage scales.
+</homebrew_and_custom_classes>
 
 <state_memo>
 - ## TRACKER STATE 0 (Current) - passed every turn, is mechanical law.

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
 
     "display_name": "Multihog D&D Framework",
 
-    "version": "2026.8.51",
+    "version": "2026.8.52",
 
     "author": "Disgusting Fatbody",
 

--- a/src/state/defaults.js
+++ b/src/state/defaults.js
@@ -1548,7 +1548,7 @@ You may be asked to use Markers: ((PLS)), ((B)), ((XB)), ((BDG)), ((HGT)). These
 
 /** Latest settings migration version — factory reset skips legacy upgrade paths at or below this. */
 
-export const FACTORY_SETTINGS_VERSION = '2026.8.48.1';
+export const FACTORY_SETTINGS_VERSION = '2026.8.49.1';
 
 
 /** Remove extension UI keys from localStorage so a factory reset does not rehydrate stale panel state. */

--- a/src/state/relationship-prompts.js
+++ b/src/state/relationship-prompts.js
@@ -110,7 +110,7 @@ export function buildRelationshipTrackingSysprompt(max) {
 [NPC_RELATIONS] at the top of each turn shows current standings with active NPCs. Scale: -${m} (deep hostility) to +${m} (deep bond). Friendship = platonic trust. Affection = romantic/emotional warmth. Point changes are absolute increments clamped to ±${m}.
 
 WHEN TO EMIT:
-- Be selective and natural. Use the NPC's injected permanent profile (if available) as a guide. What would this NPC appreciate; what might they dislike? Don't be afraid to give negative points if {{user}} acts in a way the NPC in question would dislike.
+- When {{user}} acts in a way an NPC would appreciate, admire, etc. Use the NPC's injected permanent profile (if available) as a guide. What would this NPC appreciate; what might they dislike? Don't be afraid to give negative points if {{user}} acts in a way the NPC in question would dislike.
 
 DO NOT EMIT when: the interaction has no emotional weight (buying supplies, directions), the NPC is absent, or nothing meaningful happened between {{user}} and that NPC this turn.
 

--- a/src/state/settings.js
+++ b/src/state/settings.js
@@ -1022,6 +1022,26 @@ function getSettingsInternal(extensionSettings) {
         s.settingsVersion = '2026.8.48.1';
     }
 
+    // 2026.8.49.1: stock prompt moved <relationship_tracking> above <homebrew_and_custom_classes>.
+    // Swap those Control Room keys when still in the prior stock relative order.
+    if (isOlderThan(s.settingsVersion, '2026.8.49.1')) {
+        const homebrewKey = 'base:homebrew_and_custom_classes';
+        const relationshipKey = 'base:relationship_tracking';
+        const swapHomebrewRelationshipOrder = (order) => {
+            if (!Array.isArray(order)) return;
+            const hi = order.indexOf(homebrewKey);
+            const ri = order.indexOf(relationshipKey);
+            if (hi === -1 || ri === -1 || ri <= hi) return;
+            order[hi] = relationshipKey;
+            order[ri] = homebrewKey;
+        };
+        swapHomebrewRelationshipOrder(s.syspromptSectionOrder);
+        for (const snapshot of Object.values(s.chatStates || {})) {
+            swapHomebrewRelationshipOrder(snapshot?.setup?.syspromptSectionOrder);
+        }
+        s.settingsVersion = '2026.8.49.1';
+    }
+
     // Stamp factory version even when a release has no field rewrites
     // (8.28.0 mapped-site index is prompt/injection only).
     if (isOlderThan(s.settingsVersion, FACTORY_SETTINGS_VERSION)) {

--- a/sysprompt.txt
+++ b/sysprompt.txt
@@ -140,13 +140,23 @@ Award XP inline (+[X] XP — [reason]) for real consequences: new info, new thre
 LEVEL THRESHOLDS: 1–0 | 2–300 | 3–900 | 4–2,700 | 5–6,500 | 6–14,000 | 7–23,000 | 8–34,000 | 9–48,000 | 10–64,000, etc. Level cap is 20 per D&D.
 </xp_system>
 
-<homebrew_and_custom_classes>
-Non-standard/homebrew classes (e.g. "Electronics Hobbyist," "Mechanic") don't use martial BAB tables. Improvise by theme:
-- Pure non-combatants: BAB scales slowly (+0 early, max +2/+3 late).
-- Blue-collar/improvised fighters: moderate progression.
-- Tactical/trained operators: high progression (≈ level or slightly below).
-Realistic firearms (when writing new PC/NPC/loot/enemy gear stats — never convert mid-scene): damage ~2–3× typical D&D/PF firearm tables; scale by common sense (pistol < carbine/rifle < shotgun/LMG). Reasonable pistol baseline: 2d8+1. Attack bonuses stay normal — only damage scales.
-</homebrew_and_custom_classes>
+<relationship_tracking>
+RELATIONSHIP TRACKING — only active when [NPC_RELATIONS] appears in context.
+
+[NPC_RELATIONS] at the top of each turn shows current standings with active NPCs. Scale: -100 (deep hostility) to +100 (deep bond). Friendship = platonic trust. Affection = romantic/emotional warmth. Point changes are absolute increments clamped to ±100.
+
+WHEN TO EMIT:
+- When {{user}} acts in a way an NPC would appreciate, admire, etc. Use the NPC's injected permanent profile (if available) as a guide. What would this NPC appreciate; what might they dislike? Don't be afraid to give negative points if {{user}} acts in a way the NPC in question would dislike.
+
+DO NOT EMIT when: the interaction has no emotional weight (buying supplies, directions), the NPC is absent, or nothing meaningful happened between {{user}} and that NPC this turn.
+
+INLINE ANNOTATION (visible — place immediately after the triggering moment):
+*(Friendship: Marcus +10 — saved his life in the alley)*
+*(Affection: Elena +2 — she seemed touched by the compliment)*
+*(Friendship: Horgath the Warrior -7 — showed disrespect toward self-sacrifice)*
+
+Affection is not necessarily limited to explicitly romantic actions.
+</relationship_tracking>
 
 <level_up_protocol>
 On crossing an XP threshold mid-output:
@@ -222,23 +232,13 @@ On benching, estimate a return ETA. Just before return (never once already in-sc
 Long Rest requires ≥9h since last rest; too early → narrate restlessness, abort. In a dangerous location, roll d20 vs a danger-scaled DC for interruption. Short Rest same logic, easier DC (usually <8 unless very hostile). Roll < DC = interrupted.
 </resting>
 
-<relationship_tracking>
-RELATIONSHIP TRACKING — only active when [NPC_RELATIONS] appears in context.
-
-[NPC_RELATIONS] at the top of each turn shows current standings with active NPCs. Scale: -100 (deep hostility) to +100 (deep bond). Friendship = platonic trust. Affection = romantic/emotional warmth. Point changes are absolute increments clamped to ±100.
-
-WHEN TO EMIT:
-- Be selective and natural. Use the NPC's injected permanent profile (if available) as a guide. What would this NPC appreciate; what might they dislike? Don't be afraid to give negative points if {{user}} acts in a way the NPC in question would dislike.
-
-DO NOT EMIT when: the interaction has no emotional weight (buying supplies, directions), the NPC is absent, or nothing meaningful happened between {{user}} and that NPC this turn.
-
-INLINE ANNOTATION (visible — place immediately after the triggering moment):
-*(Friendship: Marcus +10 — saved his life in the alley)*
-*(Affection: Elena +2 — she seemed touched by the compliment)*
-*(Friendship: Horgath the Warrior -7 — showed disrespect toward self-sacrifice)*
-
-Affection is not necessarily limited to explicitly romantic actions.
-</relationship_tracking>
+<homebrew_and_custom_classes>
+Non-standard/homebrew classes (e.g. "Electronics Hobbyist," "Mechanic") don't use martial BAB tables. Improvise by theme:
+- Pure non-combatants: BAB scales slowly (+0 early, max +2/+3 late).
+- Blue-collar/improvised fighters: moderate progression.
+- Tactical/trained operators: high progression (≈ level or slightly below).
+Realistic firearms (when writing new PC/NPC/loot/enemy gear stats — never convert mid-scene): damage ~2–3× typical D&D/PF firearm tables; scale by common sense (pistol < carbine/rifle < shotgun/LMG). Reasonable pistol baseline: 2d8+1. Attack bonuses stay normal — only damage scales.
+</homebrew_and_custom_classes>
 
 <state_memo>
 - ## TRACKER STATE 0 (Current) - passed every turn, is mechanical law.

--- a/sysprompt_legacy.txt
+++ b/sysprompt_legacy.txt
@@ -139,13 +139,23 @@ Award XP inline (+[X] XP — [reason]) for real consequences: new info, new thre
 LEVEL THRESHOLDS: 1–0 | 2–300 | 3–900 | 4–2,700 | 5–6,500 | 6–14,000 | 7–23,000 | 8–34,000 | 9–48,000 | 10–64,000, etc. Level cap is 20 per D&D.
 </xp_system>
 
-<homebrew_and_custom_classes>
-Non-standard/homebrew classes (e.g. "Electronics Hobbyist," "Mechanic") don't use martial BAB tables. Improvise by theme:
-- Pure non-combatants: BAB scales slowly (+0 early, max +2/+3 late).
-- Blue-collar/improvised fighters: moderate progression.
-- Tactical/trained operators: high progression (≈ level or slightly below).
-Realistic firearms (when writing new PC/NPC/loot/enemy gear stats — never convert mid-scene): damage ~2–3× typical D&D/PF firearm tables; scale by common sense (pistol < carbine/rifle < shotgun/LMG). Reasonable pistol baseline: 2d8+1. Attack bonuses stay normal — only damage scales.
-</homebrew_and_custom_classes>
+<relationship_tracking>
+RELATIONSHIP TRACKING — only active when [NPC_RELATIONS] appears in context.
+
+[NPC_RELATIONS] at the top of each turn shows current standings with active NPCs. Scale: -100 (deep hostility) to +100 (deep bond). Friendship = platonic trust. Affection = romantic/emotional warmth. Point changes are absolute increments clamped to ±100.
+
+WHEN TO EMIT:
+- When {{user}} acts in a way an NPC would appreciate, admire, etc. Use the NPC's injected permanent profile (if available) as a guide. What would this NPC appreciate; what might they dislike? Don't be afraid to give negative points if {{user}} acts in a way the NPC in question would dislike.
+
+DO NOT EMIT when: the interaction has no emotional weight (buying supplies, directions), the NPC is absent, or nothing meaningful happened between {{user}} and that NPC this turn.
+
+INLINE ANNOTATION (visible — place immediately after the triggering moment):
+*(Friendship: Marcus +10 — saved his life in the alley)*
+*(Affection: Elena +2 — she seemed touched by the compliment)*
+*(Friendship: Horgath the Warrior -7 — showed disrespect toward self-sacrifice)*
+
+Affection is not necessarily limited to explicitly romantic actions.
+</relationship_tracking>
 
 <level_up_protocol>
 On crossing an XP threshold mid-output:
@@ -221,23 +231,13 @@ On benching, estimate a return ETA. Just before return (never once already in-sc
 Long Rest requires ≥9h since last rest; too early → narrate restlessness, abort. In a dangerous location, roll d20 vs a danger-scaled DC for interruption. Short Rest same logic, easier DC (usually <8 unless very hostile). Roll < DC = interrupted.
 </resting>
 
-<relationship_tracking>
-RELATIONSHIP TRACKING — only active when [NPC_RELATIONS] appears in context.
-
-[NPC_RELATIONS] at the top of each turn shows current standings with active NPCs. Scale: -100 (deep hostility) to +100 (deep bond). Friendship = platonic trust. Affection = romantic/emotional warmth. Point changes are absolute increments clamped to ±100.
-
-WHEN TO EMIT:
-- Be selective and natural. Use the NPC's injected permanent profile (if available) as a guide. What would this NPC appreciate; what might they dislike? Don't be afraid to give negative points if {{user}} acts in a way the NPC in question would dislike.
-
-DO NOT EMIT when: the interaction has no emotional weight (buying supplies, directions), the NPC is absent, or nothing meaningful happened between {{user}} and that NPC this turn.
-
-INLINE ANNOTATION (visible — place immediately after the triggering moment):
-*(Friendship: Marcus +10 — saved his life in the alley)*
-*(Affection: Elena +2 — she seemed touched by the compliment)*
-*(Friendship: Horgath the Warrior -7 — showed disrespect toward self-sacrifice)*
-
-Affection is not necessarily limited to explicitly romantic actions.
-</relationship_tracking>
+<homebrew_and_custom_classes>
+Non-standard/homebrew classes (e.g. "Electronics Hobbyist," "Mechanic") don't use martial BAB tables. Improvise by theme:
+- Pure non-combatants: BAB scales slowly (+0 early, max +2/+3 late).
+- Blue-collar/improvised fighters: moderate progression.
+- Tactical/trained operators: high progression (≈ level or slightly below).
+Realistic firearms (when writing new PC/NPC/loot/enemy gear stats — never convert mid-scene): damage ~2–3× typical D&D/PF firearm tables; scale by common sense (pistol < carbine/rifle < shotgun/LMG). Reasonable pistol baseline: 2d8+1. Attack bonuses stay normal — only damage scales.
+</homebrew_and_custom_classes>
 
 <state_memo>
 - ## TRACKER STATE 0 (Current) - passed every turn, is mechanical law.

--- a/tests/map-architect.test.js
+++ b/tests/map-architect.test.js
@@ -307,7 +307,7 @@ describe('Map Architect component', () => {
     it('migrates only untouched shipped prompts to the new taxonomy defaults', () => {
         const defaults = readFileSync(new URL('../src/state/defaults.js', import.meta.url), 'utf8');
         const settings = readFileSync(new URL('../src/state/settings.js', import.meta.url), 'utf8');
-        expect(defaults).toContain("FACTORY_SETTINGS_VERSION = '2026.8.48.1'");
+        expect(defaults).toContain("FACTORY_SETTINGS_VERSION = '2026.8.49.1'");
         expect(settings).toContain('promptSignature');
         expect(settings).toContain("'14870:8b5acf86'");
         expect(settings).toContain("'9025:d21f2f49'");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Swaps `<relationship_tracking>` and `<homebrew_and_custom_classes>` in stock narrator prompts (`sysprompt.txt`, `sysprompt_legacy.txt`, `constants.js`) so relationship guidance appears earlier in the system prompt.
- Updates **WHEN TO EMIT** to award points when `{{user}}` acts in ways an NPC would appreciate, admire, or dislike (guided by injected permanent profile).
- Keeps the dynamic `buildRelationshipTrackingSysprompt()` builder in sync.
- Adds settings migration `2026.8.49.1` to swap Control Room section order for setups still on the prior stock relative order.
- Bumps `FACTORY_SETTINGS_VERSION` to `2026.8.49.1` and extension manifest to `2026.8.52`.

## Test plan
- [x] `npm test -- tests/relationship-prompts.test.js tests/sysprompt-content.test.js tests/module-instructions.test.js tests/map-architect.test.js` (48 passed)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5edee74e-f996-47c5-a0ad-ce9b95db8d8a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5edee74e-f996-47c5-a0ad-ce9b95db8d8a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

