### PR TITLE
Remove Discord link from startup menu (v2026.8.61)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the **Multihog D&D Framework** will be documented in this file.
 
+## [2026.8.61] - 2026-08-27
+
+### Changed
+- **Startup menu**: Removed the Discord join badge from the character creation / onboarding screen.
+
 ## [2026.8.60] - 2026-08-27
 
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
 
     "display_name": "Multihog D&D Framework",
 
-    "version": "2026.8.60",
+    "version": "2026.8.61",
 
     "author": "Disgusting Fatbody",
 

--- a/renderer.js
+++ b/renderer.js
@@ -1973,9 +1973,6 @@ function formatValueToCurrency(totalCp, detectedCurrency) {
             const startTimeInputVal = obSettings.initialTime || '08:00 AM';
 
             return `<div class="rt-empty" style="text-align: left; align-items: flex-start; padding: 12px; gap: 10px; overflow-y: auto;">
-                <a class="rt-discord-btn" href="https://discord.gg/bgjAeWEc2p" target="_blank" rel="noopener noreferrer" title="Join Discord">
-                    <img src="https://img.shields.io/badge/Discord-Join%20Server-5865F2?style=flat-square&logo=discord&logoColor=white" alt="Discord — Join Server" height="20">
-                </a>
                 <a class="rt-bmc-btn" href="https://buymeacoffee.com/multihog" target="_blank" rel="noopener noreferrer" title="Buy Me a Coffee">
                     <img src="${escapeHtml(BUY_ME_A_COFFEE_ICON)}" alt="" width="14" height="20">
                     <span>Buy Me a Coffee</span>

--- a/src/state/defaults.js
+++ b/src/state/defaults.js
@@ -1551,7 +1551,7 @@ You may be asked to use Markers: ((PLS)), ((B)), ((XB)), ((BDG)), ((HGT)). These
 
 /** Latest settings migration version — factory reset skips legacy upgrade paths at or below this. */
 
-export const FACTORY_SETTINGS_VERSION = '2026.8.60';
+export const FACTORY_SETTINGS_VERSION = '2026.8.61';
 
 
 /** Remove extension UI keys from localStorage so a factory reset does not rehydrate stale panel state. */

--- a/style.css
+++ b/style.css
@@ -1986,22 +1986,6 @@
     line-height: 1.5;
 }
 
-.rt-discord-btn {
-    position: absolute;
-    top: 8px;
-    left: 8px;
-    z-index: 2;
-    display: inline-flex;
-    align-items: center;
-    line-height: 0;
-}
-
-.rt-discord-btn img {
-    display: block;
-    height: 20px;
-    width: auto;
-}
-
 .rt-bmc-btn {
     position: absolute;
     top: 8px;

--- a/tests/map-architect.test.js
+++ b/tests/map-architect.test.js
@@ -306,7 +306,7 @@ describe('Map Architect component', () => {
     it('migrates only untouched shipped prompts to the new taxonomy defaults', () => {
         const defaults = readFileSync(new URL('../src/state/defaults.js', import.meta.url), 'utf8');
         const settings = readFileSync(new URL('../src/state/settings.js', import.meta.url), 'utf8');
-        expect(defaults).toContain("FACTORY_SETTINGS_VERSION = '2026.8.60'");
+        expect(defaults).toContain("FACTORY_SETTINGS_VERSION = '2026.8.61'");
         expect(settings).toContain('promptSignature');
         expect(settings).toContain("'14870:8b5acf86'");
         expect(settings).toContain("'9025:d21f2f49'");

--- a/tests/onboarding-persona-options.test.js
+++ b/tests/onboarding-persona-options.test.js
@@ -126,14 +126,11 @@ describe('onboarding Player Card and ST persona options', () => {
         expect(html).toContain('Releases section of the GitHub page');
     });
 
-    it('puts a Discord join badge at the top left of the startup menu', () => {
+    it('does not show a Discord join badge on the startup menu', () => {
         const html = renderMemoAsCards('', null, {});
-        const discordAt = html.indexOf('class="rt-discord-btn"');
-        const bmcAt = html.indexOf('class="rt-bmc-btn"');
 
-        expect(discordAt).toBeGreaterThan(-1);
-        expect(bmcAt).toBeGreaterThan(discordAt);
-        expect(html).toContain('href="https://discord.gg/bgjAeWEc2p"');
-        expect(html).toContain('img.shields.io/badge/Discord-Join%20Server-5865F2');
+        expect(html).not.toContain('class="rt-discord-btn"');
+        expect(html).not.toContain('href="https://discord.gg/bgjAeWEc2p"');
+        expect(html).not.toContain('img.shields.io/badge/Discord-Join%20Server-5865F2');
     });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Removes the Discord join badge from the onboarding/character creation startup screen
- Removes unused `.rt-discord-btn` CSS
- Bumps version to **2026.8.61**

## Test plan
- [x] `npm test -- tests/onboarding-persona-options.test.js tests/map-architect.test.js`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6e967a94-0974-458a-aeff-22393c2eec7a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6e967a94-0974-458a-aeff-22393c2eec7a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

