### PR TITLE
Feature: support fractional ((slots)) for the rendering librairy

### DIFF
--- a/renderer.js
+++ b/renderer.js
@@ -402,22 +402,30 @@ export function renderDayNightBadge(str) {
                 return `<div class="rt-entity-sub-line">${labelHtml} ${escapeHtmlWithColor(value)}</div>`;
             }
             case 'slots': {
-                const pm = value.match(/(\d+)\s*\/\s*(\d+)/);
+                const pm = value.match(/(\d+(?:\.\d+)?|\.\d+)\s*\/\s*(\d+(?:\.\d+)?|\.\d+)/);
                 if (pm) {
-                    const cur = parseInt(pm[1], 10), max = parseInt(pm[2], 10);
+                    const rawCurrent = Number(pm[1]), rawMax = Number(pm[2]);
+                    const cur = Math.max(0, Math.min(rawCurrent, rawMax));
+                    const max = rawMax;
                     const extra = value.replace(pm[0], '').trim();
                     let barBg = rule.color ? rule.color : '#aaaaaa';
                     if (barId) barBg = getBarBackground(barId, barBg, max > 0 ? (cur/max)*100 : 0);
-                    const recolorData = barId ? ` data-recolor-id="${escapeHtml(barId)}" data-recolor-current="${escapeHtml(barBg)}" title="Click to recolor"` : '';
+                    const recolorData = barId ? ` data-recolor-id="${escapeHtml(barId)}" data-recolor-current="${escapeHtml(barBg)}"` : '';
                     
                     let slotsHtml = '';
-                    for (let i = 0; i < max; i++) {
-                        const isFilled = i < cur;
-                        slotsHtml += `<div class="rt-slot ${isFilled ? 'filled' : 'empty'}" style="${isFilled ? `background:${barBg};` : ''}"></div>`;
+                    for (let i = 0; i < Math.ceil(max); i++) {
+                        const fill = Math.max(0, Math.min(1, cur - i));
+                        const isFilled = fill >= 1;
+                        const isPartial = fill > 0 && fill < 1;
+                        const fillHtml = fill > 0
+                            ? `<span class="rt-slot-fill" style="width:${fill * 100}%;background:${barBg};"></span>`
+                            : '';
+                        slotsHtml += `<div class="rt-slot ${isFilled ? 'filled' : isPartial ? 'partial' : 'empty'}">${fillHtml}</div>`;
                     }
+                    const tooltip = `${labelText || 'Value'} ${pm[1]}/${pm[2]}${extra ? ` ${extra}` : ''}`;
                     
                     return `<div class="rt-entity-sub-line rt-slots-row">${labelHtml}
-                        <div class="rt-slots-container"${recolorData}>${slotsHtml}</div>
+                        <div class="rt-slots-container"${recolorData} title="${escapeHtml(tooltip)}" aria-label="${escapeHtml(tooltip)}">${slotsHtml}</div>
                         <span class="rt-slots-label">${extra ? escapeHtml(extra) : ''}</span>
                     </div>`;
                 }

--- a/style.css
+++ b/style.css
@@ -9724,12 +9724,16 @@ dialog .rt-dungeon-graph-asset-tip,
 .rt-slots-container { display: flex; gap: 2px; flex-wrap: wrap; max-width: 150px; cursor: pointer; }
 .rt-slot {
     width: 12px; height: 12px;
+    position: relative;
+    overflow: hidden;
     border-radius: 2px;
     background: rgba(0,0,0,0.5);
     border: 1px solid rgba(255,255,255,0.3);
     transition: background 0.3s ease;
 }
 .rt-slot.filled { border-color: transparent; }
+.rt-slot.partial { border-color: rgba(255,255,255,0.3); }
+.rt-slot-fill { display: block; height: 100%; border-radius: 1px; }
 
 /* PHASE */
 .rt-phase-row { display: flex; align-items: center; gap: 8px; }

--- a/tests/renderer-npc-barrel.test.js
+++ b/tests/renderer-npc-barrel.test.js
@@ -37,6 +37,24 @@ describe('((BARREL))', () => {
     });
 });
 
+describe('((SLOTS))', () => {
+    it('renders decimal values with a proportional partial slot and exact hover value', () => {
+        const html = tryRenderMarker('Supply: ((SLOTS)) 1.5/4', 'CUSTOM');
+
+        expect(html).toContain('class="rt-slot partial"');
+        expect(html).toContain('class="rt-slot-fill" style="width:50%');
+        expect(html).toContain('title="Supply: 1.5/4"');
+        expect(html).toContain('aria-label="Supply: 1.5/4"');
+    });
+
+    it('accepts fractional values without a leading zero', () => {
+        const html = tryRenderMarker('Charge: ((SLOTS)) .25/1', 'CUSTOM');
+
+        expect(html).toContain('class="rt-slot partial"');
+        expect(html).toContain('title="Charge: .25/1"');
+    });
+});
+
 describe('universal tag colors', () => {
     it('applies named color suffixes dynamically without listing color variants', () => {
         expect(getMarkerLibraryKeys()).toEqual(expect.arrayContaining(['PILL', 'BAR', 'PROGRESS']));


### PR DESCRIPTION
Hello
Trying to make an Ironsworm cartrige but the track system use a 10 slot logic where you can have like 1/4 or 1/2 slots filed.
So i added fraction support for slots. I hope thats ok
```
Vow: Slay the Dragon
((SLOTS)) 7/10 (Formidable)
Journeys: Explore the forest
((SLOTS)) 2.25/10 (Epic)
Journeys: Explore the manor
((SLOTS)) 8.5/10 (Epic)
```
<img width="814" height="482" alt="firefox_tDmNk2LSD2" src="https://github.com/user-attachments/assets/f07bc5c0-126b-48cf-b115-45b8010071e7" />
Also show exact value on hover
<img width="480" height="169" alt="firefox_qXwJtgyWkk" src="https://github.com/user-attachments/assets/d7e808f8-bfa4-49fd-9c45-11e739e5cd9c" />
