### PR TITLE
Added option for background auto update

### DIFF
--- a/immersion.js
+++ b/immersion.js
@@ -36,12 +36,15 @@ export function syncCurrentLocationBackground(scene) {
     if (scene?.locationImage) applyLocationImageToChatBackground(scene.locationImage);
 }
 
-globalThis._rpgSyncCurrentLocationBackground = async (locationPath) => {
+globalThis._rpgSyncCurrentLocationBackground = async () => {
     const s = getSettings();
     if (!s.portraitAutoApplyLocationBackground || !s.locationImages) return;
-    const scene = await buildImmersionSceneState(s.currentMemo, s);
-    if (scene.storagePath === normalizeLocationPath(locationPath)) syncCurrentLocationBackground(scene);
+    // The builder applies the current image before loading NPCs. Reapplying its
+    // result here could overwrite a newer scene that finished while NPCs loaded.
+    await buildImmersionSceneState(s.currentMemo, s);
 };
+
+let latestBackgroundSceneRequest = 0;
 
 /**
  * @param {object} ctx
@@ -203,8 +206,10 @@ export async function loadNpcEntryByKey(entryId, settings) {
  * @returns {Promise<object>}
  */
 export async function buildImmersionSceneState(memo, settings) {
+    const backgroundRequest = ++latestBackgroundSceneRequest;
     const s = settings || getSettings();
     const ctx = SillyTavern.getContext();
+    const backgroundChatId = ctx.chatId;
 
     const rawLocationText = getCurrentLocationText(memo ?? s.currentMemo, ctx);
     const prefix = getEffectiveRouterCampaignPrefix(ctx.chatId);
@@ -243,7 +248,12 @@ export async function buildImmersionSceneState(memo, settings) {
     }
 
     const locationImage = storagePath ? resolveLocationImageWithMeta(storagePath).src : '';
-    syncCurrentLocationBackground({ locationImage });
+    const liveCtx = SillyTavern.getContext();
+    if (backgroundRequest === latestBackgroundSceneRequest
+        && backgroundChatId === liveCtx.chatId
+        && rawLocationText === getCurrentLocationText(getSettings().currentMemo, liveCtx)) {
+        syncCurrentLocationBackground({ locationImage });
+    }
     const locationBreadcrumb = resolvedPath ? formatLocationBreadcrumb(resolvedPath) : '';
     const locationLeaf = resolvedPath ? resolvedPath.split(' :: ').pop() : rawLocationText;
 

--- a/immersion.js
+++ b/immersion.js
@@ -1,6 +1,6 @@
 import { getSettings, getEffectiveRouterCampaignPrefix, saveChatState } from './state-manager.js';
 import { escapeHtml } from './memo-processor.js';
-import { normalizeLocationPath, resolveLocationImageWithMeta, triggerBackgroundLocationGeneration, hasLocationImage, getLinkedPlayerCharacter, isLocationImageGenerating, resolvePortraitSrcForPlayerCharacter } from './portraits.js';
+import { normalizeLocationPath, resolveLocationImageWithMeta, triggerBackgroundLocationGeneration, hasLocationImage, getLinkedPlayerCharacter, isLocationImageGenerating, resolvePortraitSrcForPlayerCharacter, applyLocationImageToChatBackground } from './portraits.js';
 import { resolvePortraitDisplaySrc, lookupCustomPortraitSrc } from './portrait-storage.js';
 import { resolveCurrentLocationPath, formatLocationBreadcrumb } from './location-resolver.js';
 import { isWorldInfoBookKnown, scanRecentOutputForPresentNpcs } from './router.js';
@@ -28,6 +28,20 @@ export function getCurrentLocationText(memo, ctx) {
     const locMatch = (memo || '').match(/Location:\s*([^)\n]+)/i);
     return locMatch ? locMatch[1].trim() : '';
 }
+
+/** Apply the current location image when the user opted into chat-background syncing. */
+export function syncCurrentLocationBackground(scene) {
+    const s = getSettings();
+    if (!s.portraitAutoApplyLocationBackground || !s.locationImages) return;
+    if (scene?.locationImage) applyLocationImageToChatBackground(scene.locationImage);
+}
+
+globalThis._rpgSyncCurrentLocationBackground = async (locationPath) => {
+    const s = getSettings();
+    if (!s.portraitAutoApplyLocationBackground || !s.locationImages) return;
+    const scene = await buildImmersionSceneState(s.currentMemo, s);
+    if (scene.storagePath === normalizeLocationPath(locationPath)) syncCurrentLocationBackground(scene);
+};
 
 /**
  * @param {object} ctx
@@ -229,6 +243,7 @@ export async function buildImmersionSceneState(memo, settings) {
     }
 
     const locationImage = storagePath ? resolveLocationImageWithMeta(storagePath).src : '';
+    syncCurrentLocationBackground({ locationImage });
     const locationBreadcrumb = resolvedPath ? formatLocationBreadcrumb(resolvedPath) : '';
     const locationLeaf = resolvedPath ? resolvedPath.split(' :: ').pop() : rawLocationText;
 

--- a/index.js
+++ b/index.js
@@ -1523,6 +1523,7 @@ export function syncLocationImageDependentUi(settings) {
 
     // Auto-gen locations requires Show Location Images; RT mode is always toggleable (enables location images when turned on).
     syncCheckbox('rpg_tracker_portrait_auto_locations', lorebookAutoOn, !imagesEnabled || realTimeOn);
+    syncCheckbox('rpg_tracker_portrait_auto_apply_location_background', !!settings.portraitAutoApplyLocationBackground, !imagesEnabled);
     syncCheckbox('rpg_tracker_portrait_auto_scene_view', realTimeOn, false);
     // Keep this available as an emergency kill switch. Turning location images
     // off also stops and disables any active Real-Time generation.
@@ -3536,6 +3537,7 @@ function loadProfile(name) {
     s.portraitAutoGenerateEnemies = p.portraitAutoGenerateEnemies ?? false;
     s.portraitAutoGenerateNpcs = p.portraitAutoGenerateNpcs ?? false;
     s.portraitAutoGenerateLocations = p.portraitAutoGenerateLocations ?? false;
+    s.portraitAutoApplyLocationBackground = p.portraitAutoApplyLocationBackground ?? false;
     s.portraitAutoGenerateSceneView = p.portraitAutoGenerateSceneView ?? false;
     s.portraitRealtimeTriggerMode = ['location_enter', 'location_change', 'every_n_outputs'].includes(p.portraitRealtimeTriggerMode)
         ? p.portraitRealtimeTriggerMode
@@ -3694,6 +3696,7 @@ function loadProfile(name) {
     $('#rpg_tracker_portrait_auto_enemies').prop('checked', !!s.portraitAutoGenerateEnemies);
     $('#rpg_tracker_portrait_auto_npcs').prop('checked', !!s.portraitAutoGenerateNpcs);
     $('#rpg_tracker_portrait_auto_locations').prop('checked', !!s.portraitAutoGenerateLocations);
+    $('#rpg_tracker_portrait_auto_apply_location_background').prop('checked', !!s.portraitAutoApplyLocationBackground);
     $('#rpg_tracker_portrait_auto_scene_view').prop('checked', !!s.portraitAutoGenerateSceneView);
     $('#rpg_tracker_location_images').prop('checked', !!s.locationImages);
     syncNpcPortraitDependentUi(s);
@@ -7415,6 +7418,15 @@ function organizeConnectionSettingsUI() {
             saveSettings();
             if (settings.portraitAutoGenerateLocations) {
                 forceCheckAutoGenerations(refreshAll);
+            }
+        });
+
+        $('#rpg_tracker_portrait_auto_apply_location_background').prop('checked', !!settings.portraitAutoApplyLocationBackground).on('change', function () {
+            if (!settings.locationImages) return;
+            settings.portraitAutoApplyLocationBackground = !!$(this).prop('checked');
+            saveSettings();
+            if (settings.portraitAutoApplyLocationBackground) {
+                void refreshLorebookAgentViewsNow();
             }
         });
 

--- a/portraits.js
+++ b/portraits.js
@@ -2012,6 +2012,15 @@ export function hasLocationImage(path) {
     return !!(s.customLocationImages && s.customLocationImages[norm]);
 }
 
+/** Apply a location image to SillyTavern's live chat background without changing its saved background selection. */
+export function applyLocationImageToChatBackground(src) {
+    if (!src || typeof document === 'undefined') return;
+    const background = document.getElementById('bg1');
+    if (!background) return;
+    const escapedSrc = String(src).replace(/["\\\r\n]/g, '\\$&');
+    background.style.backgroundImage = `url("${escapedSrc}")`;
+}
+
 /**
  * @param {string} locationPath Full hierarchical path
  * @param {string|null} src Image URL, data URL, managed path, or null to clear
@@ -2052,6 +2061,7 @@ export async function applyLocationImageData(locationPath, src, opts = {}) {
             await deletePortraitFile(previous);
         }
         await saveSettings(true);
+        if (src) void globalThis._rpgSyncCurrentLocationBackground?.(normPath);
         return;
     }
 
@@ -2075,6 +2085,7 @@ export async function applyLocationImageData(locationPath, src, opts = {}) {
         }
     }
     await saveSettings(true);
+    if (src) void globalThis._rpgSyncCurrentLocationBackground?.(normPath);
 }
 
 /**

--- a/settings.html
+++ b/settings.html
@@ -412,6 +412,12 @@
                                                 title="When enabled (and Real-Time Visualization Mode is off), scene images are auto-generated in the background for new location entries that do not already have an image. Also turns on Show Location Images. Disabled while Real-Time Visualization Mode is on."></i>
                                         </label>
                                         <label class="checkbox_label">
+                                            <input id="rpg_tracker_portrait_auto_apply_location_background" type="checkbox" />
+                                            <span>Use Location Images as Chat Background</span>
+                                            <i class="fa-solid fa-circle-question interactable"
+                                                title="When enabled, the current location image is applied as the SillyTavern chat background. A newly added image is applied immediately when it belongs to the current location."></i>
+                                        </label>
+                                        <label class="checkbox_label">
                                             <input id="rpg_portrait_location_include_present_npcs" type="checkbox" />
                                             <span>Include Present NPCs in Location Scene Prompts</span>
                                             <i class="fa-solid fa-circle-question interactable"

--- a/src/state/defaults.js
+++ b/src/state/defaults.js
@@ -319,6 +319,7 @@ export function buildDefaultSettings() {
         npcPortraits: true,
 
         locationImages: false,
+        portraitAutoApplyLocationBackground: false,
 
         npcRelationshipBars: false,
         npcRelationshipUpdateMode: 'state_tracker',

--- a/src/state/profiles.js
+++ b/src/state/profiles.js
@@ -134,6 +134,7 @@ export function saveProfile(name) {
         portraitAutoGenerateEnemies: s.portraitAutoGenerateEnemies ?? false,
         portraitAutoGenerateNpcs: s.portraitAutoGenerateNpcs ?? false,
         portraitAutoGenerateLocations: s.portraitAutoGenerateLocations ?? false,
+        portraitAutoApplyLocationBackground: s.portraitAutoApplyLocationBackground ?? false,
         portraitAutoGenerateSceneView: s.portraitAutoGenerateSceneView ?? false,
         portraitRealtimeTriggerMode: s.portraitRealtimeTriggerMode || 'location_change',
         portraitRealtimeEveryNOutputs: Math.max(1, Number(s.portraitRealtimeEveryNOutputs) || 1),

--- a/tests/location-background.test.js
+++ b/tests/location-background.test.js
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const host = vi.hoisted(() => ({ settings: {}, context: {}, images: {} }));
+vi.mock('../state-manager.js', () => ({
+    getSettings: () => host.settings,
+    getEffectiveRouterCampaignPrefix: () => '',
+}));
+vi.mock('../memo-processor.js', () => ({}));
+vi.mock('../portraits.js', () => ({
+    normalizeLocationPath: path => String(path || '').trim(),
+    resolveLocationImageWithMeta: path => ({ src: host.images[path] || '' }),
+    applyLocationImageToChatBackground: vi.fn(),
+    getLinkedPlayerCharacter: () => null,
+    isLocationImageGenerating: () => false,
+}));
+vi.mock('../portrait-storage.js', () => ({}));
+vi.mock('../router.js', () => ({
+    isWorldInfoBookKnown: vi.fn(),
+    scanRecentOutputForPresentNpcs: vi.fn(),
+}));
+vi.mock('../dungeon-reality.js', () => ({}));
+vi.mock('../dungeon-map-graph.js', () => ({}));
+vi.mock('../src/ui/panel/dungeon-map-panel.js', () => ({}));
+vi.mock('../src/state/section-enabled.js', () => ({ isLocationMappingEnabled: () => false }));
+vi.mock('../src/app/runtime-state.js', () => ({ runtimeState: {} }));
+
+import { buildImmersionSceneState } from '../immersion.js';
+import { applyLocationImageToChatBackground } from '../portraits.js';
+import { isWorldInfoBookKnown, scanRecentOutputForPresentNpcs } from '../router.js';
+
+function deferred() {
+    let resolve;
+    const promise = new Promise(done => { resolve = done; });
+    return { promise, resolve };
+}
+
+function setLocation(location, chatId = 'chat') {
+    host.context = { chatId, chat: [{ mes: `(Location: ${location})` }] };
+}
+
+describe('location background syncing', () => {
+    beforeEach(() => {
+        vi.resetAllMocks();
+        host.settings = { locationImages: true, portraitAutoApplyLocationBackground: true };
+        host.images = { A: 'A.png', B: 'B.png' };
+        setLocation('A');
+        vi.spyOn(SillyTavern, 'getContext').mockImplementation(() => host.context);
+        isWorldInfoBookKnown.mockResolvedValue(false);
+        scanRecentOutputForPresentNpcs.mockResolvedValue([]);
+    });
+
+    it('applies the current image when opted in', async () => {
+        await buildImmersionSceneState();
+        expect(applyLocationImageToChatBackground).toHaveBeenCalledExactlyOnceWith('A.png');
+    });
+
+    it.each(['portraitAutoApplyLocationBackground', 'locationImages'])('respects disabled %s', async key => {
+        host.settings[key] = false;
+        await buildImmersionSceneState();
+        await globalThis._rpgSyncCurrentLocationBackground('A');
+        expect(applyLocationImageToChatBackground).not.toHaveBeenCalled();
+    });
+
+    it('leaves the background alone when the location has no image', async () => {
+        host.images = {};
+        await buildImmersionSceneState();
+        expect(applyLocationImageToChatBackground).not.toHaveBeenCalled();
+    });
+
+    it('does not reapply an upload scene after a newer location refresh', async () => {
+        const npcs = deferred();
+        const scanning = deferred();
+        scanRecentOutputForPresentNpcs.mockImplementationOnce(() => {
+            scanning.resolve();
+            return npcs.promise;
+        });
+        const uploadSync = globalThis._rpgSyncCurrentLocationBackground('A');
+        await scanning.promise;
+        setLocation('B');
+        await buildImmersionSceneState();
+        npcs.resolve([]);
+        await uploadSync;
+        expect(applyLocationImageToChatBackground.mock.calls).toEqual([['A.png'], ['B.png']]);
+    });
+
+    it('discards an older scene whose lorebook lookup finishes last', async () => {
+        const lookup = deferred();
+        isWorldInfoBookKnown.mockReturnValueOnce(lookup.promise);
+        const oldScene = buildImmersionSceneState();
+        setLocation('B');
+        await buildImmersionSceneState();
+        lookup.resolve(false);
+        await oldScene;
+        expect(applyLocationImageToChatBackground.mock.calls).toEqual([['B.png']]);
+    });
+
+    it.each(['location', 'chat'])('discards a pending scene when the %s changes without another refresh', async change => {
+        const lookup = deferred();
+        isWorldInfoBookKnown.mockReturnValueOnce(lookup.promise);
+        const oldScene = buildImmersionSceneState();
+        setLocation(change === 'location' ? 'B' : 'A', change === 'chat' ? 'other-chat' : 'chat');
+        lookup.resolve(false);
+        await oldScene;
+        expect(applyLocationImageToChatBackground).not.toHaveBeenCalled();
+    });
+});

--- a/tests/portrait-chat-scope.test.js
+++ b/tests/portrait-chat-scope.test.js
@@ -85,6 +85,15 @@ describe('per-chat portrait ownership', () => {
         expect(hordeFn).not.toContain('pinnedApply');
     });
 
+    it('syncs the current location image to the chat background only when opted in', () => {
+        const immersionSource = readFileSync(new URL('../immersion.js', import.meta.url), 'utf8');
+        const portraitsSource = readFileSync(new URL('../portraits.js', import.meta.url), 'utf8');
+        expect(immersionSource).toContain('syncCurrentLocationBackground({ locationImage });');
+        expect(immersionSource).toContain('portraitAutoApplyLocationBackground');
+        expect(portraitsSource).toContain('_rpgSyncCurrentLocationBackground?.(normPath)');
+        expect(portraitsSource).toContain('applyLocationImageToChatBackground');
+    });
+
     it('wires chat switching, persistence, and renames to the active portrait partition only', () => {
         const indexSource = readFileSync(new URL('../index.js', import.meta.url), 'utf8');
         const portraitsSource = readFileSync(new URL('../portraits.js', import.meta.url), 'utf8');

--- a/tests/profile-location-background.test.js
+++ b/tests/profile-location-background.test.js
@@ -1,0 +1,19 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { getSettings } from '../src/state/settings.js';
+import { saveProfile } from '../src/state/profiles.js';
+import { configureRuntimeActions } from '../src/app/runtime-bridge.js';
+import { testExtensionSettings } from './setup.js';
+
+describe('location background profile preference', () => {
+    beforeEach(() => {
+        for (const key of Object.keys(testExtensionSettings)) delete testExtensionSettings[key];
+        configureRuntimeActions({ saveSettings: async () => {} });
+    });
+
+    it.each([true, false])('saves the %s preference for profile restoration', enabled => {
+        const settings = getSettings();
+        settings.portraitAutoApplyLocationBackground = enabled;
+        saveProfile('background');
+        expect(settings.profiles.background.portraitAutoApplyLocationBackground).toBe(enabled);
+    });
+});

--- a/tests/settings-overlay.test.js
+++ b/tests/settings-overlay.test.js
@@ -5,8 +5,17 @@ const stubMarkup = readFileSync(new URL('../settings-stub.html', import.meta.url
 const overlaySource = readFileSync(new URL('../src/ui/settings-overlay.js', import.meta.url), 'utf8');
 const style = readFileSync(new URL('../style.css', import.meta.url), 'utf8');
 const indexSource = readFileSync(new URL('../index.js', import.meta.url), 'utf8');
+const settingsMarkup = readFileSync(new URL('../settings.html', import.meta.url), 'utf8');
+const defaultsSource = readFileSync(new URL('../src/state/defaults.js', import.meta.url), 'utf8');
 
 describe('settings overlay', () => {
+    it('adds an opt-in location image chat background setting', () => {
+        expect(settingsMarkup).toContain('id="rpg_tracker_portrait_auto_apply_location_background"');
+        expect(settingsMarkup).toContain('Use Location Images as Chat Background');
+        expect(defaultsSource).toContain('portraitAutoApplyLocationBackground: false');
+        expect(indexSource).toContain('portraitAutoApplyLocationBackground');
+    });
+
     it('ships a stub entry point for the extensions drawer', () => {
         expect(stubMarkup).toContain('class="rpg-tracker-settings-stub"');
         expect(stubMarkup).toContain('id="rpg_tracker_open_settings"');


### PR DESCRIPTION
Implemented the opt-in location background feature.

Changes:

Added Use Location Images as Chat Background beside Auto-Generate Locations.
Default is off.
Applies the current location image during scene refresh.
Applies newly uploaded/generated images immediately when they belong to the current location.
Does not replace the background when no location image exists.
Added regression tests.
Validation: full suite passes, 913/913 tests.
<img width="1590" height="399" alt="firefox_rK1GggRizM" src="https://github.com/user-attachments/assets/5b991184-0d17-45f0-82d4-7e24ad327526" />
<img width="3825" height="1719" alt="firefox_8H1oRdELXM" src="https://github.com/user-attachments/assets/facd5aea-46c0-4bc9-b6ef-43c97a201a83" />
