### PR TITLE
feat(style): remove empty HP bar space for entities without HP

### DIFF
--- a/style.css
+++ b/style.css
@@ -3185,6 +3185,11 @@
     border-bottom: 1px solid rgba(255,255,255,0.06);
 }
 
+/* No HP bar for this entity: let the name span the full row instead of reserving the bar/label columns. */
+.rt-entity-row:not(:has(.rt-hp-bar-wrap)) {
+    grid-template-columns: 1fr;
+}
+
 .rt-entity-row:last-child { border-bottom: none; }
 
 .rt-entity-name {


### PR DESCRIPTION
Adjust entity row grid layout so names span the full row when no HP bar exists, instead of reserving unused columns.
Before (red line added just to show where to look for)
<img width="859" height="512" alt="firefox_HwWWc70Jox" src="https://github.com/user-attachments/assets/49ffb08c-4f4e-4bc2-a12a-063fd3b4a99b" />
After
<img width="872" height="486" alt="firefox_mdAvuli73C" src="https://github.com/user-attachments/assets/6288b45c-9a32-4848-8b27-6c1bc6c58588" />
(On NPC)
<img width="864" height="370" alt="firefox_lqJFiqhT8m" src="https://github.com/user-attachments/assets/9eb9f26f-2b70-4db5-9697-f6a637477719" />

