### PR TITLE
Add /get-state-memo and /set-state-memo commands for state memo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the **Multihog D&D Framework** will be documented in this file.
 
+## [2026.8.87] - 2026-09-11
+
+### Added
+- **`/get-state-memo` and `/set-state-memo` slash commands**: Read the full state memo or a single `[BLOCK]` without an LLM pass. `/get-state-memo block=TIME` returns just the content (`Day 2`); `/get-state-memo TIME` (positional) returns the wrapped block (`[TIME]\nDay 2\n[/TIME]`). `/set-state-memo block=TIME Day 2` sets one block's content (merging into existing memo), or `/set-state-memo <full memo>` replaces everything. Block id uses named `block=` argument so quoted content is never misparsed. `/set-state-memo` pushes the same Linear Stone History delta/version entry as a narrative or Direct Prompt update, so `[ LIVE ]` navigation and the delta panel see the change.
+
 ## [2026.8.86] - 2026-09-10
 
 ### Fixed

--- a/narrative-hooks.js
+++ b/narrative-hooks.js
@@ -14,12 +14,13 @@
 
 import { getSettings, hydrateWorldProgressionFromChatState, persistWorldProgressionTimer, persistRouterLastRunWatermark, persistMapUpdaterLastRunTimestamp, persistMapUpdaterLastRunWatermark, persistMapUpdaterState, getNpcRelationshipMax, clampRelationshipValue, relationshipBarPct, getFriendshipTier, getAffectionTier, applyRelTierBadgeElement, showRelationshipFloatFeedback, saveChatState, getActiveChatId, getRelationshipUpdateMode, RELATIONSHIP_UPDATE_MODES, shouldProcessRegexRelationshipUpdates, stripCoreMarkersForNarrator } from './state-manager.js';
 import { syncCombatProfile, isCombatActive } from './llm-client.js';
-import { parseQuestsFromMemo, extractCurrentTimeStr, cleanMessageContent, formatInWorldTime, memoForGmContext, stripPromptInjectionsFromUserText, stripCyoaAndPacingInjections } from './memo-processor.js';
-import { runRouterPass, saveSceneToLorebook, scanAssistantOutputForKeywords, parseInWorldMinutes, runWorldProgressionPass, updateLorebookEntry, getLorebookManifest, rollbackRouterPass, isRouterRunning, syncDungeonMapsToLocationLorebook } from './router.js';
+import { parseQuestsFromMemo, extractCurrentTimeStr, cleanMessageContent, formatInWorldTime, memoForGmContext, stripPromptInjectionsFromUserText, stripCyoaAndPacingInjections, mergeMemo, applyQuestSyncAndStripMemo, computeDelta } from './memo-processor.js';
+import { parseMemoBlocks } from './renderer.js';
+import { runRouterPass, saveSceneToLorebook, scanAssistantOutputForKeywords, parseInWorldMinutes, runWorldProgressionPass, updateLorebookEntry, getLorebookManifest, rollbackRouterPass, isRouterRunning, syncDungeonMapsToLocationLorebook, captureActiveDungeonMapHistory } from './router.js';
 import { getActiveMapUpdaterSiteRoot, maybeRollbackMapUpdaterForSwipe, runMapUpdaterPass, shouldForceBuildingPopulationPass, stopMapUpdaterPass } from './map-updater.js';
 import { maybeRollbackMapEvolutionForSwipe, maybeRunMapEvolution, stopMapEvolutionPass } from './map-evolution.js';
 import { formatNarratorSiteActivity } from './map-evolution-lib.js';
-import { shiftMemoAndMapHistory } from './src/state/dungeon-map-history.js';
+import { shiftMemoAndMapHistory, ensureDungeonMapHistory, sliceMemoAndMapHistory, unshiftMemoAndMapHistory } from './src/state/dungeon-map-history.js';
 import { canCommitPassForChat } from './src/state/pass-affinity.js';
 import { logTransaction } from './debug-viewer.js';
 import { recordSchedulerEvent } from './swipe-scheduler-debug.js';
@@ -928,6 +929,120 @@ export function registerDiceSlashCommand() {
             SlashCommandArgument.fromProps({
                 description: 'run | regular | full | audit | lookback N | N (omit for a regular update)',
                 isRequired: false,
+                typeList: [ARGUMENT_TYPE.STRING],
+            }),
+        ],
+    }));
+
+    SlashCommandParser.addCommandObject(SlashCommand.fromProps({
+        name: 'get-state-memo',
+        callback: async (args, value) => {
+            const settings = getSettings();
+            const memo = String(settings.currentMemo || '').trim();
+            const isNamed = args.block !== undefined && args.block !== null;
+            const blockId = String(args.block ?? value ?? '').trim();
+            if (!blockId) return memo;
+
+            const tag = blockId.toUpperCase();
+            const content = parseMemoBlocks(memo)[tag];
+            if (content === undefined) return '';
+            // Named argument: return just content; positional: wrap in block
+            return isNamed ? content : `[${tag}]\n${content}\n[/${tag}]`;
+        },
+        helpString: 'Get the current State Tracker memo, or a single [BLOCK] from it. '
+            + 'Usage: /get-state-memo | /get-state-memo block=&lt;BLOCK&gt;',
+        returns: 'the memo text, or the requested block only',
+        namedArgumentList: [
+            SlashCommandNamedArgument.fromProps({
+                name: 'block',
+                description: 'block id to return (e.g. CHARACTER, TIME) — omit to return the entire memo',
+                isRequired: false,
+                typeList: [ARGUMENT_TYPE.STRING],
+            }),
+        ],
+        unnamedArgumentList: [
+            SlashCommandArgument.fromProps({
+                description: 'block id to return (alternative to block=) — omit to return the entire memo',
+                isRequired: false,
+                typeList: [ARGUMENT_TYPE.STRING],
+            }),
+        ],
+    }));
+
+    SlashCommandParser.addCommandObject(SlashCommand.fromProps({
+        name: 'set-state-memo',
+        callback: async (args, value) => {
+            const settings = getSettings();
+            const currentMemo = String(settings.currentMemo || '');
+            const blockId = String(args.block ?? '').trim();
+            // Use unnamedArgumentList to preserve multiline and special chars like |
+            const unnamedArgs = args.unnamedArgumentList ?? [];
+            const content = unnamedArgs.length > 0 
+                ? unnamedArgs.join(' ').trim()
+                : String(value ?? '').trim();
+
+            let updatedMemo;
+            if (blockId) {
+                // Block form: /set-state-memo block=<BLOCK> <content>
+                if (!content) return 'Usage: /set-state-memo block=<BLOCK> <content>';
+                const tag = blockId.toUpperCase();
+                updatedMemo = mergeMemo(currentMemo, `[${tag}]\n${content}\n[/${tag}]`);
+            } else {
+                // Full memo form: /set-state-memo <full memo>
+                if (!content) return 'Usage: /set-state-memo <full memo> | /set-state-memo block=<BLOCK> <content>';
+                updatedMemo = content;
+            }
+
+            updatedMemo = applyQuestSyncAndStripMemo(updatedMemo);
+            if (updatedMemo === currentMemo) return 'No changes were made.';
+
+            // Linear Stone History: same versioning stones as a normal narrative/direct-prompt update.
+            const delta = computeDelta(currentMemo, updatedMemo);
+            settings.lastDelta = delta;
+            if (settings.historyIndex !== undefined && settings.historyIndex !== -1) {
+                sliceMemoAndMapHistory(settings, settings.historyIndex);
+            }
+            const mapSnapshot = await captureActiveDungeonMapHistory();
+            ensureDungeonMapHistory(settings);
+            if (settings.memoHistory?.[0] !== currentMemo) {
+                const previousMap = settings.historyIndex === 0
+                    ? (settings.dungeonMapHistory[0] ?? mapSnapshot)
+                    : mapSnapshot;
+                unshiftMemoAndMapHistory(settings, currentMemo, previousMap);
+            }
+            unshiftMemoAndMapHistory(settings, updatedMemo, mapSnapshot);
+            settings.historyIndex = 0;
+            runtimeState.historyViewIndex = -1;
+            runtimeState.dungeonMapHistoryOverlay = null;
+
+            const deltaPanel = document.getElementById('rpg-tracker-delta-content');
+            if (deltaPanel) deltaPanel.innerHTML = delta;
+
+            settings.prevMemo2 = settings.prevMemo1;
+            settings.prevMemo1 = currentMemo;
+            settings.currentMemo = updatedMemo;
+            saveSettings();
+            const chatId = getActiveChatId();
+            if (settings.chatLinkEnabled && chatId) saveChatState(chatId);
+            if (typeof globalThis._rpgUpdateUIMemo === 'function') globalThis._rpgUpdateUIMemo(updatedMemo);
+
+            return 'State memo updated.';
+        },
+        helpString: 'Set the entire State Tracker memo, or one [BLOCK] within it. Please escape pipe characters (|) in the content.'
+            + 'Usage: /set-state-memo &lt;full memo text&gt; | /set-state-memo block=&lt;BLOCK&gt; &lt;content&gt;',
+        returns: 'status message',
+        namedArgumentList: [
+            SlashCommandNamedArgument.fromProps({
+                name: 'block',
+                description: 'block id (e.g. TIME) to set — omit to replace the entire memo with the unnamed argument',
+                isRequired: false,
+                typeList: [ARGUMENT_TYPE.STRING],
+            }),
+        ],
+        unnamedArgumentList: [
+            SlashCommandArgument.fromProps({
+                description: 'content to set for block= (or the full memo text when block= is omitted)',
+                isRequired: true,
                 typeList: [ARGUMENT_TYPE.STRING],
             }),
         ],

--- a/narrative-hooks.js
+++ b/narrative-hooks.js
@@ -973,7 +973,9 @@ export function registerDiceSlashCommand() {
         name: 'set-state-memo',
         callback: async (args, value) => {
             const settings = getSettings();
+            const passChatId = getActiveChatId();
             const currentMemo = String(settings.currentMemo || '');
+            const historyIndexAtStart = settings.historyIndex;
             const blockId = String(args.block ?? '').trim();
             // Use unnamedArgumentList to preserve multiline and special chars like |
             const unnamedArgs = args.unnamedArgumentList ?? [];
@@ -993,6 +995,13 @@ export function registerDiceSlashCommand() {
                 updatedMemo = content;
             }
 
+            // Capture maps before mutating quests, history, or the live memo.
+            // A chat switch or another editor may finish during this lorebook read.
+            const mapSnapshot = await captureActiveDungeonMapHistory();
+            if (!canCommitPassForChat(passChatId, getActiveChatId())) return 'State memo not updated: active chat changed.';
+            if (String(settings.currentMemo || '') !== currentMemo || settings.historyIndex !== historyIndexAtStart) {
+                return 'State memo not updated: memo or history changed while preparing the update.';
+            }
             updatedMemo = applyQuestSyncAndStripMemo(updatedMemo);
             if (updatedMemo === currentMemo) return 'No changes were made.';
 
@@ -1002,7 +1011,6 @@ export function registerDiceSlashCommand() {
             if (settings.historyIndex !== undefined && settings.historyIndex !== -1) {
                 sliceMemoAndMapHistory(settings, settings.historyIndex);
             }
-            const mapSnapshot = await captureActiveDungeonMapHistory();
             ensureDungeonMapHistory(settings);
             if (settings.memoHistory?.[0] !== currentMemo) {
                 const previousMap = settings.historyIndex === 0
@@ -1022,8 +1030,7 @@ export function registerDiceSlashCommand() {
             settings.prevMemo1 = currentMemo;
             settings.currentMemo = updatedMemo;
             saveSettings();
-            const chatId = getActiveChatId();
-            if (settings.chatLinkEnabled && chatId) saveChatState(chatId);
+            if (settings.chatLinkEnabled) saveChatState(passChatId);
             if (typeof globalThis._rpgUpdateUIMemo === 'function') globalThis._rpgUpdateUIMemo(updatedMemo);
 
             return 'State memo updated.';

--- a/tests/state-memo-commands.test.js
+++ b/tests/state-memo-commands.test.js
@@ -1,0 +1,60 @@
+import { readFileSync } from 'node:fs';
+import { createContext, runInContext } from 'node:vm';
+import { describe, expect, it, vi } from 'vitest';
+import { canCommitPassForChat } from '../src/state/pass-affinity.js';
+import { mergeMemo, computeDelta } from '../memo-processor.js';
+import * as history from '../src/state/dungeon-map-history.js';
+
+const source = readFileSync(new URL('../narrative-hooks.js', import.meta.url), 'utf8');
+function harness() {
+    let chatId = 'A';
+    const settings = { currentMemo: '[TIME]\nDay 1\n[/TIME]', memoHistory: ['old'], dungeonMapHistory: [null], historyIndex: -1, chatLinkEnabled: true };
+    const snapshot = vi.fn().mockResolvedValue({ map: 'A' });
+    const questSync = vi.fn(x => x), saveChat = vi.fn();
+    const context = createContext({
+        ...history, getSettings: () => settings, getActiveChatId: () => chatId,
+        canCommitPassForChat, mergeMemo, computeDelta,
+        applyQuestSyncAndStripMemo: questSync, captureActiveDungeonMapHistory: snapshot,
+        runtimeState: {}, document: { getElementById: () => null }, saveSettings() {}, saveChatState: saveChat,
+    });
+    const start = source.indexOf('        callback:', source.indexOf("name: 'set-state-memo'"));
+    const end = source.indexOf('        helpString:', start);
+    runInContext('globalThis.run = ' + source.slice(start, end).replace(/^\s*callback:\s*/, '').trim().replace(/,$/, ''), context);
+    return { settings, snapshot, questSync, saveChat, run: context.run, switchChat: () => { chatId = 'B'; } };
+}
+function deferred() { let resolve; const promise = new Promise(done => { resolve = done; }); return { promise, resolve }; }
+
+describe('state memo slash-command commits', () => {
+    it('updates a block and records matching memo/map history', async () => {
+        const h = harness();
+        h.settings.currentMemo += '\n[CHARACTER]\nAlice\n[/CHARACTER]';
+        const previous = h.settings.currentMemo;
+        expect(await h.run({ block: 'TIME' }, 'Day 2')).toBe('State memo updated.');
+        expect(h.settings.currentMemo).toContain('Day 2');
+        expect(h.settings.currentMemo).toContain('Alice');
+        expect(h.settings.memoHistory.slice(0, 2)).toEqual([h.settings.currentMemo, previous]);
+        expect(h.settings.dungeonMapHistory).toHaveLength(h.settings.memoHistory.length);
+        expect(h.saveChat).toHaveBeenCalledWith('A');
+    });
+    it.each(['chat', 'memo', 'history'])('does not commit after a concurrent %s change', async change => {
+        const h = harness(), gate = deferred(); h.snapshot.mockReturnValue(gate.promise);
+        const pending = h.run({}, '[TIME]\nDay 2\n[/TIME]');
+        expect(h.questSync).not.toHaveBeenCalled();
+        if (change === 'chat') h.switchChat();
+        if (change === 'memo') h.settings.currentMemo = 'newer memo';
+        if (change === 'history') h.settings.historyIndex = 0;
+        const expected = structuredClone(h.settings);
+        gate.resolve(null);
+        expect(await pending).toContain('not updated');
+        expect(h.settings).toEqual(expected);
+        expect(h.questSync).not.toHaveBeenCalled();
+        expect(h.saveChat).not.toHaveBeenCalled();
+    });
+    it('does not change state when map capture fails', async () => {
+        const h = harness(), expected = structuredClone(h.settings);
+        h.snapshot.mockRejectedValue(new Error('map unavailable'));
+        await expect(h.run({}, 'replacement')).rejects.toThrow('map unavailable');
+        expect(h.settings).toEqual(expected);
+        expect(h.questSync).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
I know the basic setup expect only the LLM state tracker to modify this, but for Ironsworn cartridge i ended up building a tool that resolves the moves internally. Instead of asking the LLM to copy each stat into the tool call, i want to use a /get-state-memo so it gets it from there.
I dont personnaly plan in using the /set-state-memo as i let the tracker do the work, but since i was adding the get, i might as well add the set.

I tested and it works well as long as you escape the pipe | character from the argument.
It does register as an update for the versionning of the state tracker, and it support editing individual blocks.

---
- **`/get-state-memo` and `/set-state-memo` slash commands**: Read the full state memo or a single `[BLOCK]` without an LLM pass. `/get-state-memo block=TIME` returns just the content (`Day 2`); `/get-state-memo TIME` (positional) returns the wrapped block (`[TIME]\nDay 2\n[/TIME]`). `/set-state-memo block=TIME Day 2` sets one block's content (merging into existing memo), or `/set-state-memo <full memo>` replaces everything. Block id uses named `block=` argument so quoted content is never misparsed. `/set-state-memo` pushes the same Linear Stone History delta/version entry as a narrative or Direct Prompt update, so `[ LIVE ]` navigation and the delta panel see the change.